### PR TITLE
Allow to override the backend sys-prop from the environment.

### DIFF
--- a/embedded-cassandra/embedded-cassandra-service/src/main/java/org/hawkular/commons/cassandra/EmbeddedCassandraService.java
+++ b/embedded-cassandra/embedded-cassandra-service/src/main/java/org/hawkular/commons/cassandra/EmbeddedCassandraService.java
@@ -26,6 +26,7 @@ import javax.ejb.Singleton;
 import javax.ejb.Startup;
 
 import static org.hawkular.commons.cassandra.EmbeddedConstants.EMBEDDED_CASSANDRA_OPTION;
+import static org.hawkular.commons.cassandra.EmbeddedConstants.HAWKULAR_BACKEND_ENV_NAME;
 import static org.hawkular.commons.cassandra.EmbeddedConstants.HAWKULAR_BACKEND_PROPERTY;
 
 /**
@@ -50,6 +51,12 @@ public class EmbeddedCassandraService {
     public void start() {
         synchronized (this) {
             String backend = System.getProperty(HAWKULAR_BACKEND_PROPERTY);
+
+            String tmp = System.getenv(HAWKULAR_BACKEND_ENV_NAME);
+            if (tmp!=null) {
+                backend = tmp;
+                logger.debug("== Using backend setting from environment: " + tmp);
+            }
             if (cassandraDaemon == null && EMBEDDED_CASSANDRA_OPTION.equals(backend)) {
                 try {
                     ConfigEditor editor = new ConfigEditor();
@@ -58,8 +65,11 @@ public class EmbeddedCassandraService {
                     cassandraDaemon = new CassandraDaemon();
                     cassandraDaemon.activate();
                 } catch (Exception e) {
-                    logger.error("Error initializing embbeded Cassandra server", e);
+                    logger.error("Error initializing embedded Cassandra server", e);
                 }
+            }
+            else {
+                logger.info("== Embedded Cassandra not started as selected backend was " + backend + " ==");
             }
         }
     }

--- a/embedded-cassandra/embedded-cassandra-service/src/main/java/org/hawkular/commons/cassandra/EmbeddedConstants.java
+++ b/embedded-cassandra/embedded-cassandra-service/src/main/java/org/hawkular/commons/cassandra/EmbeddedConstants.java
@@ -26,4 +26,5 @@ public class EmbeddedConstants {
     protected static final String HAWKULAR_DATA = "hawkular-data";
     protected static final String EMBEDDED_CASSANDRA_OPTION = "embedded_cassandra";
     protected static final String HAWKULAR_BACKEND_PROPERTY = "hawkular.backend";
+    protected static final String HAWKULAR_BACKEND_ENV_NAME = "HAWKULAR_BACKEND";
 }


### PR DESCRIPTION
This is/can be used to prevent/enable starting the embedded C* database from an env variable.
This way, when using external C* nodes on Docker one can start the docker image with an env of
`-e HAWKULAR_BACKEND=""` to prevent the startup of embedded C*. 