### PR TITLE
Create CassandraDaemon as runManaged

### DIFF
--- a/embedded-cassandra/embedded-cassandra-service/src/main/java/org/hawkular/commons/cassandra/EmbeddedCassandraService.java
+++ b/embedded-cassandra/embedded-cassandra-service/src/main/java/org/hawkular/commons/cassandra/EmbeddedCassandraService.java
@@ -62,7 +62,7 @@ public class EmbeddedCassandraService {
                     ConfigEditor editor = new ConfigEditor();
                     editor.initEmbeddedConfiguration();
 
-                    cassandraDaemon = new CassandraDaemon();
+                    cassandraDaemon = new CassandraDaemon(true);
                     cassandraDaemon.activate();
                 } catch (Exception e) {
                     logger.error("Error initializing embedded Cassandra server", e);


### PR DESCRIPTION
In C* 2.2.0 a call to CassandraDaemon.deactivate() will call to a System.exit(0) if runManaged flag was not activated.
This may lead in troubles if when this call is invoked inside an app server.
