### PR TITLE
Provide a way to customize the root logger level as well as the console log level

### DIFF
--- a/hawkular-nest/hawkular-nest-feature-pack/pom.xml
+++ b/hawkular-nest/hawkular-nest-feature-pack/pom.xml
@@ -91,6 +91,13 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-logging</artifactId>
+      <version>${version.org.wildfly.core}</version>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -114,6 +121,13 @@
                   <artifactId>hawkular-bus-feature-pack</artifactId>
                   <type>zip</type>
                   <includes>configuration/standalone/template.xml,configuration/standalone/subsystems.xml</includes>
+                  <outputDirectory>${project.build.directory}/feature-pack-resources-tmp</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.wildfly.core</groupId>
+                  <artifactId>wildfly-logging</artifactId>
+                  <version>${version.org.wildfly.core}</version>
+                  <includes>subsystem-templates/logging.xml</includes>
                   <outputDirectory>${project.build.directory}/feature-pack-resources-tmp</outputDirectory>
                 </artifactItem>
               </artifactItems>
@@ -160,6 +174,20 @@
                     <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.RegExpFileMapper">
                       <pattern>^configuration/standalone/(.*).xml$</pattern>
                       <replacement>configuration/standalone/hawkular-nest-$1.xml</replacement>
+                    </fileMapper>
+                  </fileMappers>
+                </transformationSet>
+                <transformationSet>
+                  <dir>${project.build.directory}/feature-pack-resources-tmp</dir>
+                  <stylesheet>${basedir}/src/main/xsl/subsystem-templates/hawkular-nest-logging.xsl</stylesheet>
+                  <includes>
+                    <include>subsystem-templates/logging.xml</include>
+                  </includes>
+                  <outputDir>${project.build.directory}/feature-pack-resources</outputDir>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.RegExpFileMapper">
+                      <pattern>^subsystem-templates/(.*)\.xml$</pattern>
+                      <replacement>subsystem-templates/hawkular-nest-$1.xml</replacement>
                     </fileMapper>
                   </fileMappers>
                 </transformationSet>

--- a/hawkular-nest/hawkular-nest-feature-pack/src/main/xsl/subsystem-templates/hawkular-nest-logging.xsl
+++ b/hawkular-nest/hawkular-nest-feature-pack/src/main/xsl/subsystem-templates/hawkular-nest-logging.xsl
@@ -23,18 +23,23 @@
   <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" xalan:indent-amount="4" standalone="no" />
   <xsl:strip-space elements="*" />
 
-  <!-- Add the Nest subsystem -->
-  <xsl:template match="/*[name(.)='config']/*[name(.)='subsystems']">
+  <xsl:template
+      match="//*[local-name()='config']/*[local-name()='subsystem']/*[local-name()='root-logger']/*[local-name()='level']">
     <xsl:copy>
-      <xsl:apply-templates select="node()|@*"/>
-      <xsl:element name="subsystem">nest.xml</xsl:element>
+      <xsl:apply-templates select="@*|node()"/>
+      <xsl:attribute name="name">
+        <xsl:text disable-output-escaping="yes">${hawkular.log.root:INFO}</xsl:text>
+      </xsl:attribute>
     </xsl:copy>
   </xsl:template>
 
-  <!-- Use our own logging -->
-  <xsl:template match="/*[name(.)='config']/*[name(.)='subsystems']/*[name(.)='subsystem' and text()='logging.xml']">
+  <xsl:template
+      match="//*[local-name()='config']/*[local-name()='subsystem']/*[local-name()='console-handler']/*[local-name()='level']">
     <xsl:copy>
-      <xsl:text>hawkular-nest-logging.xml</xsl:text>
+      <xsl:apply-templates select="@*|node()"/>
+      <xsl:attribute name="name">
+        <xsl:text disable-output-escaping="yes">${hawkular.log.console:INFO}</xsl:text>
+      </xsl:attribute>
     </xsl:copy>
   </xsl:template>
 

--- a/hawkular-nest/hawkular-nest-itest/pom.xml
+++ b/hawkular-nest/hawkular-nest-itest/pom.xml
@@ -130,6 +130,7 @@
         <configuration>
           <systemPropertyVariables>
             <jboss.home>${project.build.directory}/${project.build.finalName}</jboss.home>
+            <jboss.options>-Xmx512m -XX:MaxPermSize=256m -Dhawkular.log.console=WARN</jboss.options>
             <shrinkwrap.maven.settings>${project.build.directory}/shrinkwrap-maven-settings.xml</shrinkwrap.maven.settings>
           </systemPropertyVariables>
         </configuration>


### PR DESCRIPTION
... by modifying system properties.

This is mostly useful to limit the output of the integration tests run
in Travis environment.