### PR TITLE
Improve the swagger documentation on inventory paths.

### DIFF
--- a/hawkular-inventory-paths/pom.xml
+++ b/hawkular-inventory-paths/pom.xml
@@ -28,6 +28,13 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <version>${version.io.swagger}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/hawkular-inventory-paths/src/main/java/org/hawkular/inventory/paths/CanonicalPath.java
+++ b/hawkular-inventory-paths/src/main/java/org/hawkular/inventory/paths/CanonicalPath.java
@@ -27,6 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
 /**
  * A path represents the canonical traversal to an element through the inventory graph. The canonical traversal
  * always starts at a tenant and follows only the "contains" relationships down to the entity in question. For
@@ -37,6 +40,15 @@ import java.util.Set;
  * @author Lukas Krejci
  * @since 0.2.0
  */
+@ApiModel(value = "CanonicalPath",
+        description = "A canonical path is slash-separated list of path segments that uniquely identity an entity" +
+        " in the Hawkular Inventory graph. The path follows the \"contains\" relationships in inventory (which form" +
+        " a tree structure). Each segment specifies the type of the element on that position in the tree, followed by" +
+        " semicolon and the ID of the element. An example of a canonical path would be" +
+        " \"/t;tenant/f;my-feed/r;my-resource\". The type is one of 't' (tenant), 'e' (environment)," +
+        " 'rt' (resource type), 'mt' (metric type), 'ot' (operation type), 'mp' (metadata pack), 'r' (resource)," +
+        " 'm' (metric), 'd' (data) or 'rl' (relationship). Please consult Hawkular Inventory documentation for a more" +
+        " thorough discussion of the different types of entities and their places in the model.", parent = Path.class)
 public final class CanonicalPath extends Path implements Iterable<CanonicalPath>, Serializable {
 
     private static final long serialVersionUID = -333891787878559703L;
@@ -199,6 +211,7 @@ public final class CanonicalPath extends Path implements Iterable<CanonicalPath>
     /**
      * @return The path to the root resource as known to this path instance.
      */
+    @ApiModelProperty(hidden = true)
     public CanonicalPath getRoot() {
         return new CanonicalPath(1, path);
     }
@@ -209,6 +222,7 @@ public final class CanonicalPath extends Path implements Iterable<CanonicalPath>
      *
      * @return the bottom-most path in the shared chain
      */
+    @ApiModelProperty(hidden = true)
     public CanonicalPath getLeaf() {
         return new CanonicalPath(path.size(), path);
     }

--- a/hawkular-inventory-paths/src/main/java/org/hawkular/inventory/paths/Path.java
+++ b/hawkular-inventory-paths/src/main/java/org/hawkular/inventory/paths/Path.java
@@ -33,6 +33,9 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
 /**
  * Represents a path in an inventory. The path is either {@link CanonicalPath} or {@link RelativePath}.
  *
@@ -81,6 +84,7 @@ import java.util.function.Function;
  * @author Lukas Krejci
  * @since 0.2.0
  */
+@ApiModel
 public abstract class Path {
 
     public static final char TYPE_DELIM = ';';
@@ -88,8 +92,13 @@ public abstract class Path {
 
     //all path instances created from this one in the up(), down() and *iterator() methods will share this list
     //and will only differ in their "myIdx" field.
+    @ApiModelProperty(hidden = true)
     protected final List<Segment> path;
+
+    @ApiModelProperty(hidden = true)
     protected final int startIdx;
+
+    @ApiModelProperty(hidden = true)
     protected final int endIdx;
 
     Path() {
@@ -234,6 +243,7 @@ public abstract class Path {
     /**
      * @return true if this is an instance of {@link CanonicalPath}, false otherwise
      */
+    @ApiModelProperty(hidden = true)
     public boolean isCanonical() {
         return this instanceof CanonicalPath;
     }
@@ -241,6 +251,7 @@ public abstract class Path {
     /**
      * @return true if this is an instance of {@link RelativePath}, false otherwise
      */
+    @ApiModelProperty(hidden = true)
     public boolean isRelative() {
         return this instanceof RelativePath;
     }
@@ -251,6 +262,7 @@ public abstract class Path {
      *
      * @return true if this path is well-formed, false otherwise.
      */
+    @ApiModelProperty(hidden = true)
     public boolean isDefined() {
         return startIdx >= 0 && endIdx > startIdx && endIdx <= path.size();
     }
@@ -299,6 +311,7 @@ public abstract class Path {
     /**
      * @return the number of ancestors. This may be less than zero for undefined paths (see {@link #isDefined()}).
      */
+    @ApiModelProperty(hidden = true)
     public int getDepth() {
         return endIdx - startIdx - 1;
     }
@@ -306,6 +319,7 @@ public abstract class Path {
     /**
      * @return the top segment in this path or null if this path is not {@link #isDefined() defined}.
      */
+    @ApiModelProperty(hidden = true)
     public Segment getTop() {
         return isDefined() ? path.get(startIdx) : null;
     }
@@ -314,6 +328,7 @@ public abstract class Path {
      * @return the last path segment on the path or null if this path is not {@link #isDefined() defined}. E.g. if this
      * path represents {@code "a/b/c"} then the segment returned from this method is {@code "c"}
      */
+    @ApiModelProperty(hidden = true)
     public Segment getSegment() {
         return isDefined() ? path.get(endIdx - 1) : null;
     }
@@ -325,6 +340,7 @@ public abstract class Path {
      *
      * @return the unmodifiable path segments or empty list if this path is {@link #isDefined() undefined}.
      */
+    @ApiModelProperty(hidden = true)
     public List<Segment> getPath() {
         return isDefined() ? path.subList(startIdx, endIdx) : Collections.emptyList();
     }

--- a/hawkular-inventory-paths/src/main/java/org/hawkular/inventory/paths/RelativePath.java
+++ b/hawkular-inventory-paths/src/main/java/org/hawkular/inventory/paths/RelativePath.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+import io.swagger.annotations.ApiModel;
+
 /**
  * A relative path is used in the API to refer to other entities during association. Its precise meaning is
  * context-sensitive but the basic idea is that given a position in the graph, you want to refer to other entities that
@@ -42,6 +44,7 @@ import java.util.function.Function;
  * @author Lukas Krejci
  * @since 0.2.0
  */
+@ApiModel
 public final class RelativePath extends Path implements Serializable {
 
     static final Map<String, Class<?>> SHORT_NAME_TYPES = new HashMap<>();

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,8 @@
     <version.com.google.code.findbugs>1.3.8</version.com.google.code.findbugs>
     <version.commons-logging.commons-logging>1.1.1</version.commons-logging.commons-logging>
 
+    <version.io.swagger>1.5.7</version.io.swagger>
+
     <!-- Keep in sync with modules/system/layers/base/org/freemarker/main in the Keycloak or Hawkular Accounts feature pack -->
     <version.org.freemarker>2.3.23</version.org.freemarker>
     <version.org.jboss.arquillian>1.1.11.Final</version.org.jboss.arquillian>


### PR DESCRIPTION
The serialized form of these is always a string with given format
so rather than letting swagger expose the inner structure of these
classes (which doesn't give the end user any meaningful information)
this describes the serialized form of the path in the
swagger-digested annotation.