### PR TITLE
Handle unknown expected type of partially untyped paths.

### DIFF
--- a/hawkular-inventory-paths/src/main/java/org/hawkular/inventory/paths/Path.java
+++ b/hawkular-inventory-paths/src/main/java/org/hawkular/inventory/paths/Path.java
@@ -946,7 +946,7 @@ public abstract class Path {
         private SegmentType unambiguousPathNextStep(SegmentType targetType, SegmentType currentType,
                 boolean isLast, Map<SegmentType, Boolean> visitedTypes) {
 
-            if (targetType.equals(currentType)) {
+            if (currentType.equals(targetType)) {
                 return targetType;
             }
 
@@ -974,7 +974,7 @@ public abstract class Path {
         private boolean fillPossiblePathsToTarget(SegmentType targetType, SegmentType currentType,
                 Set<SegmentType> result, Map<SegmentType, Boolean> visitedTypes, boolean isStart) {
 
-            if (targetType.equals(currentType)) {
+            if (currentType.equals(targetType)) {
                 if (isStart) {
                     result.add(currentType);
                 }

--- a/hawkular-inventory-paths/src/test/java/org/hawkular/inventory/paths/CanonicalPathTest.java
+++ b/hawkular-inventory-paths/src/test/java/org/hawkular/inventory/paths/CanonicalPathTest.java
@@ -358,6 +358,24 @@ public class CanonicalPathTest {
         Assert.assertEquals(new Path.Segment(SegmentType.d, "configuration"), p.slide(2, 0).getTop());
     }
 
+    @Test
+    public void testUntypedDeserializationWithUnknownTargetType() throws Exception {
+        CanonicalPath root = CanonicalPath.of().tenant("t").get();
+        try {
+            Path.fromPartiallyUntypedString("/mtype", root, null, null);
+            Assert.fail("Detyped canonical path should not have been deserializable due to lack of information.");
+        } catch (IllegalArgumentException e) {
+            //expected - we're here to check that the above doesn't throw an unintelligible NPE
+        }
+
+        try {
+            Path.fromPartiallyUntypedString("mtype", null, root, null);
+            Assert.fail("Detyped relative path should not have been deserializable due to lack of information.");
+        } catch (IllegalArgumentException e) {
+            //expected, should not be an NPE
+        }
+    }
+
     private void checkPath(CanonicalPath path, Object... pathSpec) {
         Assert.assertEquals(pathSpec.length / 2, path.getPath().size());
         for (int i = 0; i < pathSpec.length; i += 2) {


### PR DESCRIPTION
This cropped up during some inventory changes.