### PR TITLE
refactor this so the static configuration for the client does not require being in the arquillian test hierarchy.

### DIFF
--- a/hawkular-command-gateway/hawkular-command-gateway-itest/src/test/java/org/hawkular/cmdgw/ws/test/AbstractCommandITest.java
+++ b/hawkular-command-gateway/hawkular-command-gateway-itest/src/test/java/org/hawkular/cmdgw/ws/test/AbstractCommandITest.java
@@ -18,27 +18,5 @@ package org.hawkular.cmdgw.ws.test;
 
 import org.jboss.arquillian.testng.Arquillian;
 
-import com.squareup.okhttp.Credentials;
-
 public abstract class AbstractCommandITest extends Arquillian {
-
-    protected static final String authentication;
-    protected static final String baseGwUri;
-    protected static final String host;
-    protected static final String testPasword = System.getProperty("hawkular.itest.rest.password");
-    protected static final String testUser = System.getProperty("hawkular.itest.rest.user");
-    public static final String authHeader = Credentials.basic(testUser, testPasword);
-
-    static {
-        String h = System.getProperty("hawkular.bind.address", "localhost");
-        if ("0.0.0.0".equals(h)) {
-            h = "localhost";
-        }
-        host = h;
-        int portOffset = Integer.parseInt(System.getProperty("hawkular.port.offset", "0"));
-        int httpPort = portOffset + 8080;
-        baseGwUri = "ws://" + host + ":" + httpPort + "/hawkular/command-gateway";
-        authentication = "{\"username\":\"" + testUser + "\",\"password\":\"" + testPasword + "\"}";
-    }
-
 }

--- a/hawkular-command-gateway/hawkular-command-gateway-itest/src/test/java/org/hawkular/cmdgw/ws/test/ClientConfig.java
+++ b/hawkular-command-gateway/hawkular-command-gateway-itest/src/test/java/org/hawkular/cmdgw/ws/test/ClientConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.cmdgw.ws.test;
+
+import com.squareup.okhttp.Credentials;
+
+/**
+ * This provides some static configuration needed by the test client.
+ * It has no Arquillian or other test framework dependencies.
+ */
+public class ClientConfig {
+
+    protected static final String authentication;
+    protected static final String baseGwUri;
+    protected static final String host;
+    protected static final String testPasword = System.getProperty("hawkular.itest.rest.password");
+    protected static final String testUser = System.getProperty("hawkular.itest.rest.user");
+    public static final String authHeader = Credentials.basic(testUser, testPasword);
+
+    static {
+        String h = System.getProperty("hawkular.bind.address", "localhost");
+        if ("0.0.0.0".equals(h)) {
+            h = "localhost";
+        }
+        host = h;
+        int portOffset = Integer.parseInt(System.getProperty("hawkular.port.offset", "0"));
+        int httpPort = portOffset + 8080;
+        baseGwUri = "ws://" + host + ":" + httpPort + "/hawkular/command-gateway";
+        authentication = "{\"username\":\"" + testUser + "\",\"password\":\"" + testPasword + "\"}";
+    }
+
+}

--- a/hawkular-command-gateway/hawkular-command-gateway-itest/src/test/java/org/hawkular/cmdgw/ws/test/EchoCommandITest.java
+++ b/hawkular-command-gateway/hawkular-command-gateway-itest/src/test/java/org/hawkular/cmdgw/ws/test/EchoCommandITest.java
@@ -30,7 +30,7 @@ import com.squareup.okhttp.Credentials;
 public class EchoCommandITest extends AbstractCommandITest {
     public static final String GROUP = "EchoCommandITest";
 
-    private static final String echoRequestTemplate = "EchoRequest={\"authentication\": " + authentication
+    private static final String echoRequestTemplate = "EchoRequest={\"authentication\": " + ClientConfig.authentication
             + ", \"echoMessage\": \"%s\"}";
     private static final String echoResponseTemplate = "EchoResponse={\"reply\":\"ECHO [%s]\"}";
 
@@ -44,7 +44,7 @@ public class EchoCommandITest extends AbstractCommandITest {
     public void testEcho() throws Throwable {
 
         try (TestWebSocketClient testClient = TestWebSocketClient.builder()
-                .url(baseGwUri + "/ui/ws") //
+                .url(ClientConfig.baseGwUri + "/ui/ws") //
                 .expectWelcome(String.format(echoRequestTemplate, "Yodel Ay EEE Oooo")) //
                 .expectText(String.format(echoResponseTemplate, "Yodel Ay EEE Oooo"), Answer.CLOSE) //
                 .expectClose()
@@ -58,7 +58,7 @@ public class EchoCommandITest extends AbstractCommandITest {
     public void testWithoutAuth() throws Throwable {
 
         try (TestWebSocketClient testClient = TestWebSocketClient.builder()
-                .url(baseGwUri + "/ui/ws") //
+                .url(ClientConfig.baseGwUri + "/ui/ws") //
                 .authentication(null) //
                 .expectMessage(ExpectedFailure.UNAUTHORIZED) //
                 .build()) {
@@ -70,8 +70,8 @@ public class EchoCommandITest extends AbstractCommandITest {
     @Test(groups = { GROUP })
     public void testBadPassword() throws Throwable {
         try (TestWebSocketClient testClient = TestWebSocketClient.builder()
-                .url(baseGwUri + "/ui/ws") //
-                .authentication(Credentials.basic(testUser, "bad password")) //
+                .url(ClientConfig.baseGwUri + "/ui/ws") //
+                .authentication(Credentials.basic(ClientConfig.testUser, "bad password")) //
                 .expectMessage(ExpectedFailure.UNAUTHORIZED) //
                 .build()) {
             testClient.validate(10000);
@@ -82,7 +82,7 @@ public class EchoCommandITest extends AbstractCommandITest {
     @Test(groups = { GROUP })
     public void testBadUserAndPassword() throws Throwable {
         try (TestWebSocketClient testClient = TestWebSocketClient.builder()
-                .url(baseGwUri + "/ui/ws") //
+                .url(ClientConfig.baseGwUri + "/ui/ws") //
                 .authentication(Credentials.basic("baduser", "bad password")) //
                 .expectMessage(ExpectedFailure.UNAUTHORIZED) //
                 .build()) {

--- a/hawkular-command-gateway/hawkular-command-gateway-itest/src/test/java/org/hawkular/cmdgw/ws/test/TestWebSocketClient.java
+++ b/hawkular-command-gateway/hawkular-command-gateway-itest/src/test/java/org/hawkular/cmdgw/ws/test/TestWebSocketClient.java
@@ -242,7 +242,7 @@ public class TestWebSocketClient implements Closeable {
      */
     public static class Builder {
 
-        private String authentication = AbstractCommandITest.authHeader;
+        private String authentication = ClientConfig.authHeader;
 
         private final List<ExpectedEvent> expectedEvents = new ArrayList<>();
 


### PR DESCRIPTION
this helps for those tests that don't use arquillian