### PR TITLE
@NonBinding is not needed

### DIFF
--- a/hawkular-tenant-jaxrs-filter/pom.xml
+++ b/hawkular-tenant-jaxrs-filter/pom.xml
@@ -64,8 +64,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>javax</groupId>
-      <artifactId>javaee-api</artifactId>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/hawkular-tenant-jaxrs-filter/src/main/java/org/hawkular/jaxrs/filter/tenant/TenantRequired.java
+++ b/hawkular-tenant-jaxrs-filter/src/main/java/org/hawkular/jaxrs/filter/tenant/TenantRequired.java
@@ -23,8 +23,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import javax.enterprise.util.Nonbinding;
-
 /**
  * Explicitly marks a class or method on the requirement for the Hawkular-Tenant HTTP header. Method annotations have
  * priority over class annotations, so, if a method sets this as "true" and the class sets as "false", a Hawkular-Tenant
@@ -35,6 +33,5 @@ import javax.enterprise.util.Nonbinding;
 @Retention(RUNTIME)
 @Target({METHOD, TYPE})
 public @interface TenantRequired {
-    @Nonbinding
     boolean value() default true;
 }


### PR DESCRIPTION
 because the `@TenantRequired` is not used for injection or container-managed interception.

Removing it enables us to minimize the dependencies of this module.