### PR TITLE
Hawkular-inventory-paths is provided by the nest.

### DIFF
--- a/hawkular-command-gateway/hawkular-command-gateway-war/pom.xml
+++ b/hawkular-command-gateway/hawkular-command-gateway-war/pom.xml
@@ -68,6 +68,7 @@
     <dependency>
       <groupId>org.hawkular.commons</groupId>
       <artifactId>hawkular-inventory-paths</artifactId>
+      <scope>provided</scope> <!-- the nest provides this -->
     </dependency>
 
     <dependency>

--- a/hawkular-command-gateway/hawkular-command-gateway-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/hawkular-command-gateway/hawkular-command-gateway-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -23,6 +23,7 @@
     <dependencies>
       <module name="org.hawkular.bus" />
       <module name="org.hawkular.commons.cassandra-driver" />
+      <module name="org.hawkular.commons.hawkular-inventory-paths"/>
       <module name="javaee.api" />
       <module name="org.wildfly.extension.messaging-activemq" />
     </dependencies>


### PR DESCRIPTION
The cmd gateway war should not package it, and it should
declare a dependency in jboss-deployment-structure.xml