### PR TITLE
Related to Hawkular-1101, Backfiller does not honor DOWN availability

### DIFF
--- a/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/FeedWebSocketClosedEvent.schema.json
+++ b/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/FeedWebSocketClosedEvent.schema.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "extends": {
+    "type": "object",
+    "javaType": "org.hawkular.bus.common.AbstractMessage"
+  },
+  "javaType": "org.hawkular.cmdgw.api.FeedWebSocketClosedEvent",
+  "description": "Command gateway bus notification of Feed WebSocket closure event.",
+  "additionalProperties": false,
+  "properties": {
+    "feedId": {
+      "type": "string"
+    },
+    "reason": {
+      "type": "string"
+    },
+    "code": {
+      "type": "string"
+    }
+  },
+  "required": ["feedId","code"]
+}

--- a/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/log/MsgLogger.java
+++ b/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/log/MsgLogger.java
@@ -185,4 +185,9 @@ public interface MsgLogger extends BasicLogger {
 
     @Message(id = 41, value = "Failed to lookup [%s] using name [%s]")
     String errFailedToLookupConnectionFactory(String connectionFactoryClassName, String name);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 42, value = "Failed sending feed closed message to bus: feedId [%s], reason [%s], code [%s]")
+    void errorFailedSendFeedClosedEvent(@Cause Throwable t, String feedId, String reason, String code);
+
 }


### PR DESCRIPTION
For feeds establishing a websocket connection to the server we
want to detect when the WS is closed, and use that information
to backfill avails for the resources managed by that feed. So,
put a message on the bus that can be picked up by a hawkular-level
(aka glue) listener and actioned on.

@jmazzitelli please review