### PR TITLE
Hawkular-1104 Multiple Event Issue

### DIFF
--- a/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/Constants.java
+++ b/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/Constants.java
@@ -42,7 +42,8 @@ public interface Constants {
     Endpoint FEED_COMMAND_QUEUE = new Endpoint(Type.QUEUE, "FeedCommandQueue");
     Endpoint UI_COMMAND_QUEUE = new Endpoint(Type.QUEUE, "UiCommandQueue");
 
-    Endpoint EVENTS_COMMAND_TOPIC = new Endpoint(Type.TOPIC, "HawkularCommandEvent");
+    Endpoint EVENTS_COMMAND_QUEUE = new Endpoint(Type.QUEUE, "HawkularCommandEvent");
+    Endpoint HAWKULAR_TOPIC = new Endpoint(Type.TOPIC, "HawkularTopic");
 
     String CONNECTION_FACTORY_JNDI_LOOKUP_TIMEOUT_MS = "hawkular.cmdgw.connectionFactoryLookupTimeoutMs";
     int CONNECTION_FACTORY_JNDI_LOOKUP_TIMEOUT_MS_DEFAULT = 30000;

--- a/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/command/ws/EventDestinationWsCommand.java
+++ b/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/command/ws/EventDestinationWsCommand.java
@@ -31,7 +31,7 @@ import org.hawkular.cmdgw.log.MsgLogger;
  * subsystem.
  * <p>
  * This particular command implementation always puts the message on the
- * {@link Constants#EVENTS_COMMAND_TOPIC} bus endpoint.
+ * {@link Constants#EVENTS_COMMAND_QUEUE} bus endpoint.
  */
 public class EventDestinationWsCommand implements WsCommand<EventDestination> {
     private static final MsgLogger log = GatewayLoggers.getLogger(EventDestinationWsCommand.class);
@@ -42,7 +42,7 @@ public class EventDestinationWsCommand implements WsCommand<EventDestination> {
         EventDestination request = message.getBasicMessage();
         try (ConnectionContextFactory ccf = new ConnectionContextFactory(context.getConnectionFactory())) {
 
-            ProducerConnectionContext pcc = ccf.createProducerConnectionContext(Constants.EVENTS_COMMAND_TOPIC);
+            ProducerConnectionContext pcc = ccf.createProducerConnectionContext(Constants.EVENTS_COMMAND_QUEUE);
             MessageId mid = new MessageProcessor().send(pcc, request);
             log.debugf("Event forwarded to bus: mid=[%s], request=[%s]", mid, request);
         }

--- a/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/command/ws/server/FeedWebSocket.java
+++ b/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/command/ws/server/FeedWebSocket.java
@@ -59,7 +59,7 @@ public class FeedWebSocket extends AbstractGatewayWebSocket {
         // Notify bus that connection to the feed has been lost
         WsCommandContext context = commandContextFactory.newCommandContext(session);
         try (ConnectionContextFactory ccf = new ConnectionContextFactory(context.getConnectionFactory())) {
-            Endpoint endpoint = Constants.EVENTS_COMMAND_TOPIC;
+            Endpoint endpoint = Constants.HAWKULAR_TOPIC;
             ProducerConnectionContext pcc = ccf.createProducerConnectionContext(endpoint);
             FeedWebSocketClosedEvent message = new FeedWebSocketClosedEvent();
             message.setFeedId(feedId);


### PR DESCRIPTION
- Continue publishing command events to HawkularCommandEvent but convert
  it to a queue as opposed to a topic, limiting message consumption to a
  single handler.
- Change publishing FeedWebSocketClosed events from HawkularCommandEvent
  to a new topic, HawkularTopic.  This improves separation of concern,
  and maintains topic publishing for this event message.