### PR TITLE
Hawkular 1096 ansible commands (do not merge)

### DIFF
--- a/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/AnsibleRequest.schema.json
+++ b/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/AnsibleRequest.schema.json
@@ -11,11 +11,15 @@
     "playbook": {
       "type": "string"
     },
+    "resourcePath": {
+      "description" : "The inventory path to the resource that is targeted by this request.",
+      "type": "string"
+    },
     "extraVars": {
       "description" : "Extra variables to pass to the Ansible playbook. This maps to the --extra-vars Ansible command line option.",
       "javaType" : "java.util.Map<String,String>",
       "type": "object"
     }
   },
-  "required": ["playbook"]
+  "required": ["resourcePath","playbook"]
 }

--- a/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/AnsibleRequest.schema.json
+++ b/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/AnsibleRequest.schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "extends": {
+    "type": "object",
+    "javaType": "org.hawkular.cmdgw.api.AuthMessage"
+  },
+  "javaType": "org.hawkular.cmdgw.api.AnsibleRequest",
+  "description": "A request to invoke an Ansible playbook.",
+  "additionalProperties": false,
+  "properties": {
+    "playbook": {
+      "type": "string"
+    }
+  },
+  "required": ["playbook"]
+}

--- a/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/AnsibleRequest.schema.json
+++ b/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/AnsibleRequest.schema.json
@@ -10,6 +10,11 @@
   "properties": {
     "playbook": {
       "type": "string"
+    },
+    "extraVars": {
+      "description" : "Extra variables to pass to the Ansible playbook. This maps to the --extra-vars Ansible command line option.",
+      "javaType" : "java.util.Map<String,String>",
+      "type": "object"
     }
   },
   "required": ["playbook"]

--- a/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/AnsibleResponse.schema.json
+++ b/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/AnsibleResponse.schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "extends": {
+    "type": "object",
+    "javaType": "org.hawkular.cmdgw.api.AuthMessage"
+  },
+  "javaType": "org.hawkular.cmdgw.api.AnsibleResponse",
+  "description": "The results of an Ansible playbook invocation.",
+  "additionalProperties": false,
+  "properties": {
+    "results": {
+      "type": "string"
+    }
+  },
+  "required": ["results"]
+}

--- a/hawkular-command-gateway/hawkular-command-gateway-war/pom.xml
+++ b/hawkular-command-gateway/hawkular-command-gateway-war/pom.xml
@@ -89,6 +89,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-api</artifactId>
+      <version>0.17.1.Final</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/command/ws/AnsibleCommand.java
+++ b/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/command/ws/AnsibleCommand.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.cmdgw.command.ws;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import org.hawkular.bus.common.BasicMessageWithExtraData;
+import org.hawkular.cmdgw.api.AnsibleRequest;
+import org.hawkular.cmdgw.api.AnsibleResponse;
+import org.hawkular.cmdgw.command.ws.server.WebSocketHelper;
+
+public class AnsibleCommand implements WsCommand<AnsibleRequest> {
+
+    @Override
+    public void execute(BasicMessageWithExtraData<AnsibleRequest> message, WsCommandContext context)
+            throws Exception {
+        AnsibleRequest ansibleRequest = message.getBasicMessage();
+        String playbook = ansibleRequest.getPlaybook();
+        File playbookFile = getAnsiblePlaybook(playbook);
+
+        // return the response
+        AnsibleResponse ansibleResponse = new AnsibleResponse();
+        ansibleResponse.setResults(String.format("Ansible Playbook [%s] results here!", playbookFile));
+        BasicMessageWithExtraData<AnsibleResponse> result = new BasicMessageWithExtraData<>(ansibleResponse, null);
+        new WebSocketHelper().sendSync(context.getSession(), result);
+    }
+
+    private File getAnsiblePlaybook(String playbook) throws Exception {
+        File configDir = new File(System.getProperty("jboss.server.config.dir"));
+        for (File file : configDir.listFiles()) {
+            if (file.getName().equals(playbook)) {
+                return file;
+            }
+        }
+        throw new FileNotFoundException(String.format("Cannot find Ansible playbook [%s]", playbook));
+    }
+
+}

--- a/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/command/ws/AnsibleCommand.java
+++ b/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/command/ws/AnsibleCommand.java
@@ -16,8 +16,14 @@
  */
 package org.hawkular.cmdgw.command.ws;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import org.hawkular.bus.common.BasicMessageWithExtraData;
 import org.hawkular.cmdgw.api.AnsibleRequest;
@@ -29,25 +35,88 @@ public class AnsibleCommand implements WsCommand<AnsibleRequest> {
     @Override
     public void execute(BasicMessageWithExtraData<AnsibleRequest> message, WsCommandContext context)
             throws Exception {
-        AnsibleRequest ansibleRequest = message.getBasicMessage();
-        String playbook = ansibleRequest.getPlaybook();
-        File playbookFile = getAnsiblePlaybook(playbook);
 
-        // return the response
+        // determine what Ansible command line should be executed
+        AnsibleRequest ansibleRequest = message.getBasicMessage();
+        List<String> commandLine = getAnsibleCommandLine(ansibleRequest);
+
+        // build the Ansible command
+        ProcessBuilder pb = new ProcessBuilder(commandLine);
+        pb.directory(getAnsibleFilesLocation());
+        pb.redirectErrorStream(true);
+
+        // run the Ansible command and wait for it to finish
+        Process process = pb.start();
+        process.waitFor(); // TODO this blocks indefinitely. We'll want to implement a timeout somehow
+
+        // get the results of the Ansible command
+        int exitValue = process.exitValue();
+        InputStream processOutput = new BufferedInputStream(process.getInputStream());
+        String processOutputString = slurpInputStream(processOutput);
+
+        // put the Ansible output in our response
         AnsibleResponse ansibleResponse = new AnsibleResponse();
-        ansibleResponse.setResults(String.format("Ansible Playbook [%s] results here!", playbookFile));
+        ansibleResponse.setResults(String.format("Exit code=[%d]\nOutput:\n%s", exitValue, processOutputString));
         BasicMessageWithExtraData<AnsibleResponse> result = new BasicMessageWithExtraData<>(ansibleResponse, null);
+
+        // send the Ansible response to the client
         new WebSocketHelper().sendSync(context.getSession(), result);
     }
 
-    private File getAnsiblePlaybook(String playbook) throws Exception {
-        File configDir = new File(System.getProperty("jboss.server.config.dir"));
-        for (File file : configDir.listFiles()) {
-            if (file.getName().equals(playbook)) {
+    private List<String> getAnsibleCommandLine(AnsibleRequest ansibleRequest) throws Exception {
+        List<String> commandLine = new ArrayList<>();
+
+        commandLine.add("ansible-playbook");
+
+        commandLine.add("-i");
+        commandLine.add(getAnsibleFile("hosts").getAbsolutePath());
+
+        Map<String, String> extraVars = ansibleRequest.getExtraVars();
+        if (extraVars != null) {
+            for (Map.Entry<String, String> extraVar : extraVars.entrySet()) {
+                commandLine.add("-e");
+                commandLine.add(extraVar.getKey() + "=" + extraVar.getValue());
+            }
+        }
+
+        File playbookFile = getAnsibleFile(ansibleRequest.getPlaybook());
+        commandLine.add(playbookFile.getAbsolutePath());
+
+        return commandLine;
+    }
+
+    private String slurpInputStream(InputStream inputStream) throws Exception {
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int length;
+        while ((length = inputStream.read(buffer)) != -1) {
+            result.write(buffer, 0, length);
+        }
+        return result.toString("UTF-8");
+    }
+
+    private File getAnsibleFile(String filename) throws Exception {
+        File dir = getAnsibleFilesLocation();
+        for (File file : dir.listFiles()) {
+            if (file.getName().equals(filename)) {
                 return file;
             }
         }
-        throw new FileNotFoundException(String.format("Cannot find Ansible playbook [%s]", playbook));
+        throw new FileNotFoundException(String.format("Cannot find Ansible file [%s] in [%s]", filename, dir));
+    }
+
+    private File getAnsibleFilesLocation() throws Exception {
+        String configDirProperty = System.getProperty("jboss.server.config.dir");
+        if (configDirProperty == null) {
+            throw new FileNotFoundException("Cannot find the location of the Ansible files");
+        }
+
+        File ansibleFilesLocation = new File(configDirProperty, "ansible");
+        if (!ansibleFilesLocation.isDirectory()) {
+            throw new FileNotFoundException("The Ansible files directory is missing: " + ansibleFilesLocation);
+        }
+
+        return ansibleFilesLocation;
     }
 
 }

--- a/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/command/ws/WsCommands.java
+++ b/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/command/ws/WsCommands.java
@@ -23,6 +23,7 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.hawkular.bus.common.BasicMessage;
 import org.hawkular.cmdgw.NoCommandForMessageException;
+import org.hawkular.cmdgw.api.AnsibleRequest;
 import org.hawkular.cmdgw.api.EchoRequest;
 import org.hawkular.cmdgw.api.EventDestination;
 import org.hawkular.cmdgw.api.ResourcePathDestination;
@@ -40,11 +41,12 @@ public class WsCommands {
     // Notice we instantiate them here - these must be thread-safe.
 
     private final ResourcePathDestinationWsCommand resourcePathDestinationWsCommand = //
-    new ResourcePathDestinationWsCommand();
+            new ResourcePathDestinationWsCommand();
 
     private final EchoCommand echoCommand = new EchoCommand();
     private final UiSessionDestinationWsCommand uiSessionDestinationWsCommand = new UiSessionDestinationWsCommand();
     private final EventDestinationWsCommand eventDestinationWsCommand = new EventDestinationWsCommand();
+    private final AnsibleCommand ansibleCommand = new AnsibleCommand();
 
     /**
      * Returns a collection of {@link WsCommand}s that should handle the given {@code requestClass}.
@@ -65,14 +67,15 @@ public class WsCommands {
             results.add((WsCommand<REQ>) uiSessionDestinationWsCommand);
         } else if (EchoRequest.class.isAssignableFrom(requestClass)) {
             results.add((WsCommand<REQ>) echoCommand);
+        } else if (AnsibleRequest.class.isAssignableFrom(requestClass)) {
+            results.add((WsCommand<REQ>) ansibleCommand);
         }
+        // new commands will need to be added here
 
         // some commands may also want the message sent to events
         if (EventDestination.class.isAssignableFrom(requestClass)) {
             results.add((WsCommand<REQ>) eventDestinationWsCommand);
         }
-
-        // new commands will need to be added here
 
         if (results.isEmpty()) {
             throw new NoCommandForMessageException(

--- a/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/command/ws/WsCommands.java
+++ b/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/command/ws/WsCommands.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import org.hawkular.bus.common.BasicMessage;
 import org.hawkular.cmdgw.NoCommandForMessageException;
@@ -46,7 +47,9 @@ public class WsCommands {
     private final EchoCommand echoCommand = new EchoCommand();
     private final UiSessionDestinationWsCommand uiSessionDestinationWsCommand = new UiSessionDestinationWsCommand();
     private final EventDestinationWsCommand eventDestinationWsCommand = new EventDestinationWsCommand();
-    private final AnsibleCommand ansibleCommand = new AnsibleCommand();
+
+    @Inject
+    private AnsibleCommand ansibleCommand;
 
     /**
      * Returns a collection of {@link WsCommand}s that should handle the given {@code requestClass}.

--- a/hawkular-command-gateway/hawkular-command-gateway-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/hawkular-command-gateway/hawkular-command-gateway-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -24,6 +24,7 @@
       <module name="org.hawkular.bus" />
       <module name="org.hawkular.commons.cassandra-driver" />
       <module name="org.hawkular.commons.hawkular-inventory-paths"/>
+      <module name="deployment.hawkular-inventory-dist.war" services="import"/>
       <module name="javaee.api" />
       <module name="org.wildfly.extension.messaging-activemq" />
     </dependencies>


### PR DESCRIPTION
This PR is not intended for merge. I want to show a problem that I have trying to get information from the inventory.

One thing I trying to do is: given a resource canonical path through an AnsibleRequest, get the host, bind IP, and WildFly home path and pass it to ansible via extraVars so ansible playbook can access to that information. I'm doing all of this inside the AnsibleCommand.

I tried to use the inventory API on the AnsibleCommand to get Wildfly configurations, but this injects a dependency here and this is bad because this is the common project (all projects including inventory depends on it)

In this line I fetch the information:
https://github.com/rubenvp8510/hawkular-commons/blob/94ec515c22b5dc942e7bdccb3b8cc1904ee07a3d/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/command/ws/AnsibleCommand.java#L63

One solution could be doing a separate module for processing the ansible request, and in the command put the request in a queue. that could work?
