### PR TITLE
Upgrade findbugs 1.3.8 -> 1.3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
 
   <properties>
     <version.javax.javaee>7.0</version.javax.javaee>
-    <version.com.google.code.findbugs>1.3.8</version.com.google.code.findbugs>
+    <version.com.google.code.findbugs>1.3.9</version.com.google.code.findbugs>
     <version.commons-logging.commons-logging>1.1.1</version.commons-logging.commons-logging>
 
     <!-- Keep in sync with modules/system/layers/base/org/freemarker/main in the Keycloak or Hawkular Accounts feature pack -->


### PR DESCRIPTION
The 1.3.8 version has a bad POM for jsr305 artifact (incorrect artifactId)
Also this syncs the version with some other projects