### PR TITLE
hwkalerts-174 Add CORS support

### DIFF
--- a/hawkular-cors-jaxrs-filter/pom.xml
+++ b/hawkular-cors-jaxrs-filter/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>hawkular-commons-parent</artifactId>
+    <groupId>org.hawkular.commons</groupId>
+    <version>0.7.9.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hawkular-cors-jaxrs-filter</artifactId>
+
+  <name>Hawkular REST Filter - CORS</name>
+  <description>
+    A reusable implementation of a filter that provides Cross-Origin Resource Sharing (CORS) for REST endpoints.
+  </description>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-javaee7</artifactId>
+        <version>${version.org.wildfly.bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.arquillian</groupId>
+        <artifactId>arquillian-bom</artifactId>
+        <version>${version.org.jboss.arquillian}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly.arquillian</groupId>
+        <artifactId>wildfly-arquillian-parent</artifactId>
+        <version>${version.org.wildfly.arquillian}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/hawkular-cors-jaxrs-filter/src/main/java/org/hawkular/jaxrs/filter/cors/AbstractCorsResponseFilter.java
+++ b/hawkular-cors-jaxrs-filter/src/main/java/org/hawkular/jaxrs/filter/cors/AbstractCorsResponseFilter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.jaxrs.filter.cors;
+
+import java.io.IOException;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+/**
+ * @author Stefan Negrea
+ */
+public abstract class AbstractCorsResponseFilter implements ContainerResponseFilter {
+
+    protected abstract boolean isAllowedOrigin(String requestOrigin);
+
+    protected abstract String getExtraAccessControlAllowHeaders();
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+            throws IOException {
+
+        String requestOrigin = requestContext.getHeaderString(Headers.ORIGIN);
+        if (requestOrigin == null) {
+            return;
+        }
+
+        if (isAllowedOrigin(requestOrigin)) {
+            MultivaluedMap<String, Object> responseHeaders = responseContext.getHeaders();
+            responseHeaders.add(Headers.ACCESS_CONTROL_ALLOW_ORIGIN, requestOrigin);
+            responseHeaders.add(Headers.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+            responseHeaders.add(Headers.ACCESS_CONTROL_ALLOW_METHODS,
+                    Headers.DEFAULT_CORS_ACCESS_CONTROL_ALLOW_METHODS);
+            responseHeaders.add(Headers.ACCESS_CONTROL_MAX_AGE, 72 * 60 * 60);
+
+            String extraAccesControlAllowHeaders = getExtraAccessControlAllowHeaders();
+            if (extraAccesControlAllowHeaders != null) {
+                responseHeaders.add(Headers.ACCESS_CONTROL_ALLOW_HEADERS,
+                        Headers.DEFAULT_CORS_ACCESS_CONTROL_ALLOW_HEADERS + ","
+                                + extraAccesControlAllowHeaders.trim());
+            } else {
+                responseHeaders.add(Headers.ACCESS_CONTROL_ALLOW_HEADERS,
+                        Headers.DEFAULT_CORS_ACCESS_CONTROL_ALLOW_HEADERS);
+            }
+        } else {
+            responseContext.setStatus(Response.Status.BAD_REQUEST.getStatusCode());
+        }
+    }
+}

--- a/hawkular-cors-jaxrs-filter/src/main/java/org/hawkular/jaxrs/filter/cors/AbstractOriginValidation.java
+++ b/hawkular-cors-jaxrs-filter/src/main/java/org/hawkular/jaxrs/filter/cors/AbstractOriginValidation.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.jaxrs.filter.cors;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @author Stefan Negrea
+ */
+public abstract class AbstractOriginValidation {
+
+    protected abstract String getAllowedCorsOrigins();
+
+    private boolean allowAnyOrigin;
+    private Set<URI> allowedOrigins;
+
+    protected void init() {
+        String allowedCorsOriginsConfig = getAllowedCorsOrigins();
+        if (Headers.ALLOW_ALL_ORIGIN.equals(allowedCorsOriginsConfig.trim())) {
+            allowAnyOrigin = true;
+        } else {
+            allowAnyOrigin = false;
+            Set<URI> parsedOrigins = Arrays.stream(allowedCorsOriginsConfig.split(","))
+                    .map(String::trim)
+                    .map(URI::create)
+                    .collect(Collectors.toSet());
+            allowedOrigins = Collections.unmodifiableSet(parsedOrigins);
+        }
+    }
+
+    /**
+     * Helper method to check whether requests from the specified origin
+     * must be allowed.
+     *
+     * @param requestOrigin origin as reported by the client, {@code null} if unknown.
+     *
+     * @return {@code true} if the origin is allowed, else {@code false}.
+     */
+    public boolean isAllowedOrigin(final String requestOrigin) {
+        if (allowAnyOrigin) {
+            return true;
+        }
+
+        if (requestOrigin == null) {
+            return false;
+        }
+
+        URI requestOriginURI;
+        try {
+            requestOriginURI = new URI(requestOrigin);
+        } catch (URISyntaxException e) {
+            return false;
+        }
+
+        String requestScheme = requestOriginURI.getScheme();
+        String requestHost = requestOriginURI.getHost();
+        int requestPort = requestOriginURI.getPort();
+
+        if (requestScheme == null || requestHost == null) {
+            return false;
+        }
+
+        for (URI allowedOrigin : allowedOrigins) {
+            if ((requestHost.equalsIgnoreCase(allowedOrigin.getHost())
+                    || requestHost.toLowerCase().endsWith("." + allowedOrigin.getHost().toLowerCase()))
+                    && requestPort == allowedOrigin.getPort()
+                    && requestScheme.equalsIgnoreCase(allowedOrigin.getScheme())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/hawkular-cors-jaxrs-filter/src/main/java/org/hawkular/jaxrs/filter/cors/CorsRequestFilter.java
+++ b/hawkular-cors-jaxrs-filter/src/main/java/org/hawkular/jaxrs/filter/cors/CorsRequestFilter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.jaxrs.filter.cors;
+
+import java.io.IOException;
+
+import javax.annotation.Priority;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * @author Stefan Negrea
+ *
+ */
+@Provider
+@PreMatching
+@Priority(0)
+public class CorsRequestFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        //NOT a CORS request
+        if (requestContext.getHeaderString(Headers.ORIGIN) == null) {
+            return;
+        }
+
+        //It is a CORS pre-flight request, there is no route for it, just return 200
+        if (requestContext.getMethod().equalsIgnoreCase(HttpMethod.OPTIONS)) {
+            requestContext.abortWith(Response.status(Response.Status.OK).build());
+        }
+    }
+}

--- a/hawkular-cors-jaxrs-filter/src/main/java/org/hawkular/jaxrs/filter/cors/Headers.java
+++ b/hawkular-cors-jaxrs-filter/src/main/java/org/hawkular/jaxrs/filter/cors/Headers.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.jaxrs.filter.cors;
+
+public class Headers {
+
+    //Header Names
+    public static final String ACCESS_CONTROL_ALLOW_CREDENTIALS = "Access-Control-Allow-Credentials";
+    public static final String ACCESS_CONTROL_ALLOW_HEADERS = "Access-Control-Allow-Headers";
+    public static final String ACCESS_CONTROL_ALLOW_METHODS = "Access-Control-Allow-Methods";
+    public static final String ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
+    public static final String ACCESS_CONTROL_MAX_AGE = "Access-Control-Max-Age";
+    public static final String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
+    public static final String ORIGIN = "Origin";
+
+    //Default CORS Values
+    public static final String DEFAULT_CORS_ACCESS_CONTROL_ALLOW_METHODS = "GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD";
+    public static final String DEFAULT_CORS_ACCESS_CONTROL_ALLOW_HEADERS = "origin,accept,content-type,hawkular-tenant";
+    public static final String ALLOW_ALL_ORIGIN = "*";
+}

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <module>hawkular-command-gateway</module>
     <module>hawkular-nest</module>
     <module>hawkular-tenant-jaxrs-filter</module>
+    <module>hawkular-cors-jaxrs-filter</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
- Because CORS is a general feature that multiple Hawkular component's
  REST APIs do, or may, support, add base support in a new commons module.
- We don't have a commons-level configuration utility (we probably
  should in order to consolidate hawkular component config).  Because
  we don't this is set up such that consuming components can configure
  it using their own mechanism.  If we ever have a common config, we
  could likely have all the CORS support in commons, with nothing
  abstract and needing component-level override.
- Thanks to Stefan, this originates with his code in Hmetrics (which should
  now likely leverage this code as well ;)

@stefannegrea Please review
