### PR TITLE
Fix license header years because subprojects have different inception…

### DIFF
--- a/hawkular-bus/hawkular-bus-common/pom.xml
+++ b/hawkular-bus/hawkular-bus-common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/AbstractMessage.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/AbstractMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/BasicMessage.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/BasicMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/BasicMessageWithExtraData.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/BasicMessageWithExtraData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/BinaryData.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/BinaryData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/Bus.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/Bus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/ConnectionContext.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/ConnectionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/ConnectionContextFactory.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/ConnectionContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/Endpoint.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/Endpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/MessageId.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/MessageId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/MessageProcessor.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/MessageProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/ObjectMessage.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/ObjectMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/SimpleBasicMessage.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/SimpleBasicMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/consumer/AbstractBasicMessageListener.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/consumer/AbstractBasicMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/consumer/BasicMessageListener.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/consumer/BasicMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/consumer/BytesMessageInputStream.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/consumer/BytesMessageInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/consumer/ConsumerConnectionContext.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/consumer/ConsumerConnectionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/consumer/RPCBasicMessageListener.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/consumer/RPCBasicMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/consumer/RPCConnectionContext.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/consumer/RPCConnectionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/log/MsgLogger.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/log/MsgLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/msg/features/FailOnUnknownProperties.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/msg/features/FailOnUnknownProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/producer/ProducerConnectionContext.java
+++ b/hawkular-bus/hawkular-bus-common/src/main/java/org/hawkular/bus/common/producer/ProducerConnectionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/main/resources/META-INF/beans.xml
+++ b/hawkular-bus/hawkular-bus-common/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,6 @@
     limitations under the License.
 
 -->
-
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"

--- a/hawkular-bus/hawkular-bus-common/src/test/java/org/hawkular/bus/common/BasicMessageObjectMapperTest.java
+++ b/hawkular-bus/hawkular-bus-common/src/test/java/org/hawkular/bus/common/BasicMessageObjectMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/test/java/org/hawkular/bus/common/BasicMessageTest.java
+++ b/hawkular-bus/hawkular-bus-common/src/test/java/org/hawkular/bus/common/BasicMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/test/java/org/hawkular/bus/common/BinaryDataTest.java
+++ b/hawkular-bus/hawkular-bus-common/src/test/java/org/hawkular/bus/common/BinaryDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/test/java/org/hawkular/bus/common/EndpointTest.java
+++ b/hawkular-bus/hawkular-bus-common/src/test/java/org/hawkular/bus/common/EndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/test/java/org/hawkular/bus/common/LoggingTest.java
+++ b/hawkular-bus/hawkular-bus-common/src/test/java/org/hawkular/bus/common/LoggingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/test/java/org/hawkular/bus/common/MessageIdTest.java
+++ b/hawkular-bus/hawkular-bus-common/src/test/java/org/hawkular/bus/common/MessageIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/test/java/org/hawkular/bus/common/ObjectMessageTest.java
+++ b/hawkular-bus/hawkular-bus-common/src/test/java/org/hawkular/bus/common/ObjectMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-common/src/test/resources/log4j.xml
+++ b/hawkular-bus/hawkular-bus-common/src/test/resources/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-feature-pack/assembly.xml
+++ b/hawkular-bus/hawkular-bus-feature-pack/assembly.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-feature-pack/feature-pack-build.xml
+++ b/hawkular-bus/hawkular-bus-feature-pack/feature-pack-build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-feature-pack/pom.xml
+++ b/hawkular-bus/hawkular-bus-feature-pack/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-feature-pack/src/main/resources/content/modules/layers.conf
+++ b/hawkular-bus/hawkular-bus-feature-pack/src/main/resources/content/modules/layers.conf
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-feature-pack/src/main/resources/modules/system/layers/hawkular/org/hawkular/bus/main/module.xml
+++ b/hawkular-bus/hawkular-bus-feature-pack/src/main/resources/modules/system/layers/hawkular/org/hawkular/bus/main/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-mdb/pom.xml
+++ b/hawkular-bus/hawkular-bus-mdb/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-mdb/src/main/java/org/hawkular/bus/mdb/RPCBasicMessageDrivenBean.java
+++ b/hawkular-bus/hawkular-bus-mdb/src/main/java/org/hawkular/bus/mdb/RPCBasicMessageDrivenBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-rest-client/pom.xml
+++ b/hawkular-bus/hawkular-bus-rest-client/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-rest-client/src/main/java/org/hawkular/bus/restclient/RestClient.java
+++ b/hawkular-bus/hawkular-bus-rest-client/src/main/java/org/hawkular/bus/restclient/RestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-rest-client/src/main/java/org/hawkular/bus/restclient/RestClientException.java
+++ b/hawkular-bus/hawkular-bus-rest-client/src/main/java/org/hawkular/bus/restclient/RestClientException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/hawkular-bus-rest-client/src/test/java/org/hawkular/bus/restclient/RestClientTest.java
+++ b/hawkular-bus/hawkular-bus-rest-client/src/test/java/org/hawkular/bus/restclient/RestClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-bus/pom.xml
+++ b/hawkular-bus/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,6 @@
   <artifactId>hawkular-bus-parent</artifactId>
   <packaging>pom</packaging>
   <name>Hawkular Bus Parent</name>
-  <inceptionYear>2015</inceptionYear>
 
   <scm>
     <connection>scm:git:git@github.com:hawkular/hawkular-bus.git</connection>

--- a/hawkular-nest/hawkular-nest-feature-pack/assembly.xml
+++ b/hawkular-nest/hawkular-nest-feature-pack/assembly.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-feature-pack/feature-pack-build.xml
+++ b/hawkular-nest/hawkular-nest-feature-pack/feature-pack-build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-feature-pack/pom.xml
+++ b/hawkular-nest/hawkular-nest-feature-pack/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-feature-pack/src/main/resources/modules/system/layers/hawkular/org/hawkular/commons/cassandra-driver/main/module.xml
+++ b/hawkular-nest/hawkular-nest-feature-pack/src/main/resources/modules/system/layers/hawkular/org/hawkular/commons/cassandra-driver/main/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-feature-pack/src/main/resources/modules/system/layers/hawkular/org/hawkular/commons/hawkular-inventory-paths/main/module.xml
+++ b/hawkular-nest/hawkular-nest-feature-pack/src/main/resources/modules/system/layers/hawkular/org/hawkular/commons/hawkular-inventory-paths/main/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-feature-pack/src/main/resources/modules/system/layers/hawkular/org/hawkular/nest/main/module.xml
+++ b/hawkular-nest/hawkular-nest-feature-pack/src/main/resources/modules/system/layers/hawkular/org/hawkular/nest/main/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-feature-pack/src/main/resources/subsystem-templates/nest.xml
+++ b/hawkular-nest/hawkular-nest-feature-pack/src/main/resources/subsystem-templates/nest.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-feature-pack/src/main/xsl/configuration/standalone/hawkular-nest-subsystems.xsl
+++ b/hawkular-nest/hawkular-nest-feature-pack/src/main/xsl/configuration/standalone/hawkular-nest-subsystems.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-feature-pack/src/main/xsl/subsystem-templates/hawkular-nest-ejb3.xsl
+++ b/hawkular-nest/hawkular-nest-feature-pack/src/main/xsl/subsystem-templates/hawkular-nest-ejb3.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-feature-pack/src/main/xsl/subsystem-templates/hawkular-nest-logging.xsl
+++ b/hawkular-nest/hawkular-nest-feature-pack/src/main/xsl/subsystem-templates/hawkular-nest-logging.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-feature-pack/src/main/xsl/subsystem-templates/hawkular-nest-messaging-activemq.xsl
+++ b/hawkular-nest/hawkular-nest-feature-pack/src/main/xsl/subsystem-templates/hawkular-nest-messaging-activemq.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-itest/pom.xml
+++ b/hawkular-nest/hawkular-nest-itest/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-itest/server-provisioning.xml
+++ b/hawkular-nest/hawkular-nest-itest/server-provisioning.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-itest/src/test/java/org/hawkular/bus/itest/BusITest.java
+++ b/hawkular-nest/hawkular-nest-itest/src/test/java/org/hawkular/bus/itest/BusITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-itest/src/test/java/org/hawkular/commons/cassandra/driver/itest/CassandraDriverITest.java
+++ b/hawkular-nest/hawkular-nest-itest/src/test/java/org/hawkular/commons/cassandra/driver/itest/CassandraDriverITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-itest/src/test/java/org/hawkular/commons/rest/status/itest/ITestStatusApp.java
+++ b/hawkular-nest/hawkular-nest-itest/src/test/java/org/hawkular/commons/rest/status/itest/ITestStatusApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-itest/src/test/java/org/hawkular/commons/rest/status/itest/RestStatusDetailsProducer.java
+++ b/hawkular-nest/hawkular-nest-itest/src/test/java/org/hawkular/commons/rest/status/itest/RestStatusDetailsProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-itest/src/test/java/org/hawkular/commons/rest/status/itest/StatusEndpointITest.java
+++ b/hawkular-nest/hawkular-nest-itest/src/test/java/org/hawkular/commons/rest/status/itest/StatusEndpointITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-itest/src/test/java/org/hawkular/inventory/paths/CanonicalPathITest.java
+++ b/hawkular-nest/hawkular-nest-itest/src/test/java/org/hawkular/inventory/paths/CanonicalPathITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-itest/src/test/resources/bus/jboss-deployment-structure.xml
+++ b/hawkular-nest/hawkular-nest-itest/src/test/resources/bus/jboss-deployment-structure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-itest/src/test/resources/cassandra-driver/jboss-deployment-structure.xml
+++ b/hawkular-nest/hawkular-nest-itest/src/test/resources/cassandra-driver/jboss-deployment-structure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-itest/src/test/resources/hawkular-inventory-paths/jboss-deployment-structure.xml
+++ b/hawkular-nest/hawkular-nest-itest/src/test/resources/hawkular-inventory-paths/jboss-deployment-structure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-itest/src/test/resources/logging.properties
+++ b/hawkular-nest/hawkular-nest-itest/src/test/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-itest/src/test/resources/rest-status/jboss-deployment-structure.xml
+++ b/hawkular-nest/hawkular-nest-itest/src/test/resources/rest-status/jboss-deployment-structure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-itest/src/test/resources/rest-status/jboss-web.xml
+++ b/hawkular-nest/hawkular-nest-itest/src/test/resources/rest-status/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-itest/src/test/resources/rest-status/web.xml
+++ b/hawkular-nest/hawkular-nest-itest/src/test/resources/rest-status/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/pom.xml
+++ b/hawkular-nest/hawkular-nest-wf-extension/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/CustomConfigAttributeDefinition.java
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/CustomConfigAttributeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestConfigurationSetup.java
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestConfigurationSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestEnabledAttributeHandler.java
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestEnabledAttributeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestService.java
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestSubsystemAdd.java
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestSubsystemAdd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestSubsystemDefinition.java
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestSubsystemDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestSubsystemExtension.java
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestSubsystemExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestSubsystemRemove.java
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestSubsystemRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestSubsystemStart.java
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestSubsystemStart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestSubsystemStatus.java
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestSubsystemStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestSubsystemStop.java
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/NestSubsystemStop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/log/MsgLogger.java
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/java/org/hawkular/nest/extension/log/MsgLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/resources/org/hawkular/nest/extension/LocalDescriptions.properties
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/resources/org/hawkular/nest/extension/LocalDescriptions.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Red Hat, Inc. and/or its affiliates
+# Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/resources/schema/nest.xsd
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/resources/schema/nest.xsd
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/scripts/standalone-subsystem.xml
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/scripts/standalone-subsystem.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/test/java/org/hawkular/nest/extension/SubsystemBaseParsingTestCase.java
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/test/java/org/hawkular/nest/extension/SubsystemBaseParsingTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/test/java/org/hawkular/nest/extension/SubsystemParsingTestCase.java
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/test/java/org/hawkular/nest/extension/SubsystemParsingTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/hawkular-nest-wf-extension/src/test/resources/org/hawkular/nest/extension/subsystem.xml
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/test/resources/org/hawkular/nest/extension/subsystem.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-nest/pom.xml
+++ b/hawkular-nest/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,6 @@
   <packaging>pom</packaging>
 
   <name>Hawkular Nest Parent</name>
-  <inceptionYear>2015</inceptionYear>
 
   <modules>
     <module>hawkular-nest-wf-extension</module>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,19 @@
         <module>hawkular-tenant-jaxrs-filter</module>
         <module>hawkular-cors-jaxrs-filter</module>
       </modules>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <configuration>
+              <excludes combine.children="append">
+                <exclude>hawkular-rest-status/src/test/resources/manifests/*.txt</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
… year settings that get ignored when submodules are not part of the reactor. The inception year should only be set at the parent pom of respository to allow selective maven reactor.