### PR TITLE
Implements EventDestination on Add/Remove Datasource  Command

### DIFF
--- a/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/AddDatasourceResponse.schema.json
+++ b/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/AddDatasourceResponse.schema.json
@@ -5,6 +5,7 @@
     "javaType": "org.hawkular.cmdgw.api.ResourcePathResponse"
   },
   "javaType": "org.hawkular.cmdgw.api.AddDatasourceResponse",
+  "javaInterfaces" : ["org.hawkular.cmdgw.api.EventDestination"],
   "description": "Results of an Add Datasource request.",
   "additionalProperties": false,
   "properties": {

--- a/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/RemoveDatasourceResponse.schema.json
+++ b/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/RemoveDatasourceResponse.schema.json
@@ -5,6 +5,7 @@
     "javaType": "org.hawkular.cmdgw.api.ResourcePathResponse"
   },
   "javaType": "org.hawkular.cmdgw.api.RemoveDatasourceResponse",
+  "javaInterfaces" : ["org.hawkular.cmdgw.api.EventDestination"],
   "description": "Results of an RemoveDatasourceRequest.",
   "additionalProperties": false
 }


### PR DESCRIPTION
Implements EventDestination interface so it triggers an event creation when someone requests an operation for add or delete Datasources.

@jshaughn I think this was the problem of the BZ 1390756 "No MW Provider Event Shown After Deleting Datasource", Could you review this, please? Thanks :) 

Also, I'm not sure if we should implement this for other commands.