### PR TITLE
Move license checker exclusions to apply globally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,21 @@
     </dependencies>
   </dependencyManagement>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <excludes combine.children="append">
+            <exclude>**/*.log</exclude>
+            <exclude>hawkular-rest-status/src/test/resources/manifests/*.txt</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>default</id>
@@ -139,19 +154,6 @@
         <module>hawkular-tenant-jaxrs-filter</module>
         <module>hawkular-cors-jaxrs-filter</module>
       </modules>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.mycila</groupId>
-            <artifactId>license-maven-plugin</artifactId>
-            <configuration>
-              <excludes combine.children="append">
-                <exclude>hawkular-rest-status/src/test/resources/manifests/*.txt</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
and exclusion for .log files because release builds started failing due to files like hs_err_pid22992.log, generated during a test (probably due to openjdk).