### PR TITLE
Optional CorsHandler for UI development

### DIFF
--- a/vertx/server/src/main/java/org/hawkular/HandlersManager.java
+++ b/vertx/server/src/main/java/org/hawkular/HandlersManager.java
@@ -24,8 +24,10 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -49,8 +51,10 @@ import io.vertx.ext.web.handler.CorsHandler;
 public class HandlersManager {
     private static final MsgLogger log = MsgLogging.getMsgLogger(HandlersManager.class);
 
-    private static final String CORS_CONFIG = "hawkular.cors-url";
-    private static final String CORS_CONFIG_DEFAULT = "";
+    private static final String CORS_URL = "hawkular.cors-url";
+    private static final String CORS_URL_DEFAULT = "";
+    private static final String CORS_HEADERS = "hawkular.cors-headers";
+    private static final String CORS_HEADERS_DEFAULT = "";
 
     private Router router;
     private Map<String, BaseApplication> applications = new HashMap<>();
@@ -59,10 +63,12 @@ public class HandlersManager {
     private Map<EndpointKey, Class<RestHandler>> endpointsClasses = new HashMap<>();
     private ClassLoader cl = Thread.currentThread().getContextClassLoader();
     private String corsUrl;
+    private String corsHeaders;
 
     public HandlersManager(Vertx vertx) {
         this.router = Router.router(vertx);
-        corsUrl = HawkularProperties.getProperty(CORS_CONFIG, CORS_CONFIG_DEFAULT);
+        corsUrl = HawkularProperties.getProperty(CORS_URL, CORS_URL_DEFAULT);
+        corsHeaders = HawkularProperties.getProperty(CORS_HEADERS, CORS_HEADERS_DEFAULT);
     }
 
     public void start() {
@@ -105,7 +111,11 @@ public class HandlersManager {
                     String baseUrl = app.baseUrl();
                     router.route(baseUrl + "*").handler(BodyHandler.create());
                     if (corsUrl.length() > 0) {
-                        router.route(baseUrl + "*").handler(CorsHandler.create(corsUrl));
+                        CorsHandler corsHandler = CorsHandler.create(corsUrl);
+                        if (corsHeaders.length() > 0) {
+                            corsHandler.allowedHeaders(extractCorsHeaders(corsHeaders));
+                        }
+                        router.route(baseUrl + "*").handler(corsHandler);
                     }
                     RestHandler handler = endpoint.getValue().newInstance();
                     handler.initRoutes(baseUrl, router);
@@ -204,6 +214,17 @@ public class HandlersManager {
             log.errorf(e, "Error loading Handler [%s].", className);
             System.exit(1);
         }
+    }
+
+    private Set<String> extractCorsHeaders(String corsHeaders) {
+        Set<String> headers = new HashSet<>();
+        if (corsHeaders != null && corsHeaders.length() > 0) {
+            String[] splitted = corsHeaders.split(",");
+            for (int i = 0; i < splitted.length; i++) {
+                headers.add(splitted[i]);
+            }
+        }
+        return headers;
     }
 
     public static class EndpointKey {


### PR DESCRIPTION
This PR adds a basic CorsHandler into the baseUrl.
During UI work, a local dev uses a different domain to access into the server and Cors rules are necessary.
Perhaps it can also get necessary in other scenarios and we might want to add more options (restrict the headers, methods, etc) but for now I think is good.