### PR TITLE
Adding property to delete JDR report file after export operation ends

### DIFF
--- a/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/ExportJdrRequest.schema.json
+++ b/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/ExportJdrRequest.schema.json
@@ -7,5 +7,12 @@
   "javaType": "org.hawkular.cmdgw.api.ExportJdrRequest",
   "javaInterfaces" : ["org.hawkular.cmdgw.api.ResourcePathDestination"],
   "description": "Exports a JDR from the Application Server instance given by the inventory path stored in resourcePath field.",
-  "additionalProperties": false
+  "additionalProperties": false,
+  "properties": {
+    "deleteImmediately": {
+      "description": "Set to false if the report should remain in the server node. Otherwise, set to true.",
+      "type": "boolean",
+      "javaType": "boolean"
+    }
+  }
 }


### PR DESCRIPTION
Export JDR operation is streaming to the client. It may not make sense
to keep a copy of it in the server node. Adding a property to allow the
client to choose if the report should be kept. Being a boolean variable,
default is to keep a copy.