### PR TITLE
start of jmx exporter configs

### DIFF
--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/resources/wildfly-10-jmx-exporter.yml
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/resources/wildfly-10-jmx-exporter.yml
@@ -1,0 +1,125 @@
+#
+# Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+startDelaySeconds: 1
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+rules:
+
+  # CONFIG
+
+  - pattern: "^jboss.as<path=(.+)><>path:(.+)"
+    attrNameSnakeCase: true
+    name: wildfly_config
+    labels:
+      $1: $2
+    value: 1
+
+  # DEPLOYMENTS
+
+  - pattern: "^jboss.as<deployment=(.+), subdeployment=(.+), subsystem=undertow><>(.+_sessions|session_.+):"
+    attrNameSnakeCase: true
+    name: wildfly_deployment_$3
+    type: GAUGE
+    labels:
+      name: $1
+      subdeployment: $2
+
+  - pattern: "^jboss.as<deployment=(.+), subsystem=undertow><>(.+_sessions|session_.+):"
+    attrNameSnakeCase: true
+    name: wildfly_deployment_$2
+    type: GAUGE
+    labels:
+      name: $1
+
+  # MESSAGING
+
+  - pattern: "^jboss.as<subsystem=messaging-activemq, server=(.+), jms-(queue|topic)=(.+)><>(.+):"
+    attrNameSnakeCase: true
+    name: wildfly_messaging_$4
+    type: GAUGE
+    labels:
+      server: $1
+      $2: $3
+
+  # DATASOURCES
+
+  - pattern: "^jboss.as<subsystem=datasources, (?:xa-)*data-source=(.+), statistics=(.+)><>(.+):"
+    attrNameSnakeCase: true
+    name: wildfly_datasource_$2_$3
+    type: GAUGE
+    labels:
+      name: $1
+
+  # TRANSACTIONS
+
+  - pattern: "^jboss.as<subsystem=transactions><>number_of_(.+):"
+    attrNameSnakeCase: true
+    name: wildfly_transactions_$1
+    type: GAUGE
+
+  # WEB SUBSYSTEM
+
+  - pattern: "^jboss.as<subsystem=undertow, server=(.+), (https?)-listener=(.+)><>(bytes_.+|error_count|processing_time|request_count):"
+    attrNameSnakeCase: true
+    name: wildfly_undertow_$4
+    type: GAUGE
+    labels:
+      server: $1
+      listener: $3
+      protocol: $2
+
+  # SERVLET
+
+  - pattern: "^jboss.as<deployment=(.+), subdeployment=(.+), subsystem=undertow, servlet=(.+)><>(.+_time|.+_count):"
+    attrNameSnakeCase: true
+    name: wildfly_servlet_$4
+    type: GAUGE
+    labels:
+      name: $3
+      deployment: $1
+      subdeployment: $2
+
+  - pattern: "^jboss.as<deployment=(.+), subsystem=undertow, servlet=(.+)><>(.+_time|.+_count):"
+    attrNameSnakeCase: true
+    name: wildfly_servlet_$3
+    type: GAUGE
+    labels:
+      name: $2
+      deployment: $1
+
+  # EJB
+
+  - pattern: "^jboss.as<deployment=(.+), subdeployment=(.+), subsystem=ejb3, (stateless-session|stateful-session|message-driven|singleton)-bean=(.+)><>(.+):"
+    attrNameSnakeCase: true
+    name: wildfly_ejb_$5
+    type: GAUGE
+    labels:
+      name: $4
+      type: $3
+      deployment: $1
+      subdeployment: $2
+
+  - pattern: "^jboss.as<deployment=(.+), subsystem=ejb3, (stateless-session|stateful-session|message-driven|singleton)-bean=(.+)><>(.+):"
+    attrNameSnakeCase: true
+    name: wildfly_ejb_$4
+    type: GAUGE
+    labels:
+      name: $3
+      type: $2
+      deployment: $1

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryRestTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryRestTest.java
@@ -224,6 +224,7 @@ public class InventoryRestTest {
                 .addAsLibraries(assertj)
                 .setWebXML(new File("src/main/webapp/WEB-INF/web.xml"))
                 .addAsResource(new File("src/main/resources/hawkular-inventory-ispn.xml"))
+                .addAsResource(new File("src/main/resources/wildfly-10-jmx-exporter.yml"))
                 .addAsWebInfResource(new File("src/main/webapp/WEB-INF/beans.xml"));
     }
 
@@ -429,6 +430,14 @@ public class InventoryRestTest {
         assertEquals(200, response.getStatus());
         assertThat(response.readEntity(new GenericType<String>() {}))
                 .contains("AGENT CONFIG TEST");
+
+        target = client.target(baseUrl.toString()).path("get-jmx-exporter-config/wildfly-10");
+        response = target
+                .request(MediaType.TEXT_PLAIN)
+                .get();
+        assertEquals(200, response.getStatus());
+        assertThat(response.readEntity(new GenericType<String>() {}))
+                .contains("- pattern:");
     }
 
     @Test

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryServiceIspnTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryServiceIspnTest.java
@@ -215,6 +215,8 @@ public class InventoryServiceIspnTest {
     public void shouldGetJMXExporterConfig() throws IOException {
         assertThat(service.getJMXExporterConfig("test")).isPresent()
                 .hasValueSatisfying(s -> assertThat(s).contains("JMX EXPORTER TEST"));
+        assertThat(service.getJMXExporterConfig("wildfly-10")).isPresent()
+                .hasValueSatisfying(s -> assertThat(s).contains("- pattern:"));
     }
 
     @Test


### PR DESCRIPTION
I just want some place to put a jmx exporter config that I configured for our first attempt. This works on wildfly 10.x.

@jotak I found an issue we need to address. Since this just builds the war, the only place I can put it is in WEB-INF/classes (along with the ispn.xml file). However, we want the user to be able to create their own or override this default file. So we need to change the REST endpoints to first look in standalone/configuration as you have it now, however, if the file is not found, look for it in the WAR classloader (and thus will pick up any default files we ship with the war).

This will also help our current distribution model - which as it stands now is just a war and we ask devs to copy the war to any wildfly standalone/deployment folder. Without this new feature, we need to ask people to also copy some yaml files to standalone.configuration in addition to putting the war in the deployment folder.

This PR adds this new feature with tests.