### PR TITLE
Add back utils for use by alerts and others.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
         <module>hawkular-nest</module>
         <module>hawkular-tenant-jaxrs-filter</module>
         <module>hawkular-cors-jaxrs-filter</module>
+        <module>utils</module>
       </modules>
     </profile>
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular.commons</groupId>
+    <artifactId>hawkular-commons-parent</artifactId>
+    <version>0.9.8.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hawkular-commons-utils</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Logging and Properties services</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+      <version>${version.org.jboss.logging}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <version>${version.org.jboss.logging.jboss-logging-tools}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <version>${version.org.jboss.logging.jboss-logging-tools}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/utils/src/main/java/org/hawkular/commons/log/MsgLogger.java
+++ b/utils/src/main/java/org/hawkular/commons/log/MsgLogger.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.commons.log;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * Default Logger.
+ * Each project can extend it with personalized messages.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@MessageLogger(projectCode = "HAWKULAR")
+public interface MsgLogger extends BasicLogger {
+}

--- a/utils/src/main/java/org/hawkular/commons/log/MsgLogging.java
+++ b/utils/src/main/java/org/hawkular/commons/log/MsgLogging.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.commons.log;
+
+import org.jboss.logging.Logger;
+
+/**
+ *
+ * Utility class to simplify logger lookup.
+ *
+ *
+ * @author Thomas Segismont
+ * @author Lucas Ponce
+ */
+public class MsgLogging {
+    public static <T> T getMsgLogger(Class<T> loggerClass, Class<?> loggedClass) {
+        return Logger.getMessageLogger(loggerClass, loggedClass.getName());
+    }
+
+    public static MsgLogger getMsgLogger(Class<?> loggedClass) {
+        return Logger.getMessageLogger(MsgLogger.class, loggedClass.getName());
+    }
+
+    private MsgLogging() {
+    }
+}

--- a/utils/src/main/java/org/hawkular/commons/properties/HawkularProperties.java
+++ b/utils/src/main/java/org/hawkular/commons/properties/HawkularProperties.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.commons.properties;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.hawkular.commons.log.MsgLogger;
+import org.hawkular.commons.log.MsgLogging;
+
+/**
+ * Read global properties from hawkular.properties file.
+ *
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class HawkularProperties {
+    private static final MsgLogger log = MsgLogging.getMsgLogger(HawkularProperties.class);
+    private static final String CONFIG_PATH = "hawkular.configuration";
+    private static final String DEFAULT_FILE = "hawkular.properties";
+
+    private static Properties properties = null;
+
+    private HawkularProperties() {
+    }
+
+    public static String getProperty(String key, String defaultValue) {
+        return getProperty(key, null, defaultValue);
+    }
+
+    public static String getProperty(String key, String envKey, String defaultValue) {
+        if (properties == null) {
+            init();
+        }
+        String value = System.getProperty(key);
+        if (value == null) {
+            if (envKey != null) {
+                value = System.getenv(envKey);
+            }
+            if (value == null) {
+                value = properties.getProperty(key, defaultValue);
+            }
+        }
+        return value;
+    }
+
+    private static void init() {
+        try {
+            String configPath = System.getProperty(CONFIG_PATH);
+            InputStream is = null;
+            if (configPath != null) {
+                File configFile = new File(configPath, DEFAULT_FILE);
+                if (configFile.exists() && configFile.isFile()) {
+                    is = new FileInputStream(configFile);
+                }
+            }
+            if (is == null) {
+                log.debug("No properties file found. Loading from ClassLoader.");
+                is = HawkularProperties.class.getClassLoader().getResourceAsStream(DEFAULT_FILE);
+            }
+            properties = new Properties();
+            properties.load(is);
+        } catch (IOException e) {
+            log.error("Error loading properties.", e);
+        }
+    }
+
+}


### PR DESCRIPTION
@lucasponce These utils  are currently used in alerts 1.8.  They seem reasonable to keep here.