### PR TITLE
Enrich status endpoint with version info

### DIFF
--- a/hawkular-inventory-parent/hawkular-inventory-service/pom.xml
+++ b/hawkular-inventory-parent/hawkular-inventory-service/pom.xml
@@ -152,6 +152,12 @@
     <finalName>hawkular-${project.artifactId}-${project.version}</finalName>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>${version.org.codehaus.buildnumber-maven-plugin}</version>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-war-plugin</artifactId>
         <version>${version.maven-war-plugin}</version>
         <configuration>
@@ -160,6 +166,12 @@
               <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
+            <manifestEntries>
+              <Implementation-Vendor-Id>org.hawkular.inventory</Implementation-Vendor-Id>
+              <Implementation-Version>${project.version}</Implementation-Version>
+              <Built-From-Git-SHA1>${buildNumber}</Built-From-Git-SHA1>
+              <Built-On>${timestamp}</Built-On>
+            </manifestEntries>
             <!-- <manifestEntries> <Build-Number>${buildNumber}</Build-Number>
               </manifestEntries> -->
           </archive>

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/handlers/InventoryHandlers.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/handlers/InventoryHandlers.java
@@ -50,6 +50,8 @@ public class InventoryHandlers {
 
     private static final MsgLogger log = InventoryLoggers.getLogger(InventoryHandlers.class);
 
+    ManifestUtil manifestUtil = new ManifestUtil();
+
     @EJB
     private InventoryService inventoryService;
 
@@ -180,6 +182,7 @@ public class InventoryHandlers {
     @Produces(APPLICATION_JSON)
     public Response status(@Context ServletContext servletContext) {
         final Map<String, String> status = new HashMap<>();
+        status.putAll(manifestUtil.getFrom());
         status.put("status", "UP");
         return Response.ok(status).build();
     }

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/handlers/ManifestUtil.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/handlers/ManifestUtil.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.handlers;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class ManifestUtil {
+    private static final String IMPLEMENTATION_VENDOR_ID = "Implementation-Vendor-Id";
+    private static final String IMPLEMENTATION_VERSION = "Implementation-Version";
+    private static final String BUILT_FROM_GIT = "Built-From-Git-SHA1";
+    private static final String HAWKULAR_INVENTORY = "org.hawkular.inventory";
+
+    private static final List<String> VERSION_ATTRIBUTES = Arrays.asList(IMPLEMENTATION_VERSION, BUILT_FROM_GIT);
+
+    private Map<String, String> manifestInformation = new HashMap<>();
+
+    public Map<String, String> getFrom() {
+        extractManifest();
+        return manifestInformation;
+    }
+
+    private void extractManifest() {
+        if (manifestInformation.isEmpty()) {
+            try {
+                Enumeration<URL> urlResources = getClass().getClassLoader().getResources("META-INF/MANIFEST.MF");
+                while (urlResources.hasMoreElements()) {
+                    URL url = urlResources.nextElement();
+                    Manifest manifest = new Manifest(url.openStream());
+                    Attributes attr = manifest.getMainAttributes();
+                    if (attr.getValue(IMPLEMENTATION_VENDOR_ID) != null
+                            && attr.getValue(IMPLEMENTATION_VENDOR_ID).equals(HAWKULAR_INVENTORY)) {
+                        for (String attribute : VERSION_ATTRIBUTES) {
+                            manifestInformation.put(attribute, attr.getValue(attribute));
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                for (String attribute : VERSION_ATTRIBUTES) {
+                    if (manifestInformation.get(attribute) == null) {
+                        manifestInformation.put(attribute, "Unknown");
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adding version on the status endpoint like

```
{"Implementation-Version":"0.9.8.Final-SNAPSHOT","Built-From-Git-SHA1":"d559f689f75ef3936b8dda51dcc053e065d40b1b","status":"UP"}
```

This will help to identify the inventory version in place (thinking on the ruby-client).

Please, @jotak can you take a look ?