### PR TITLE
Convert from infinispan-embedded to standard infinispan

### DIFF
--- a/hawkular-inventory-parent/hawkular-inventory-model/pom.xml
+++ b/hawkular-inventory-parent/hawkular-inventory-model/pom.xml
@@ -32,12 +32,9 @@
 
   <dependencies>
 
-    <!-- TODO this dependency would need to be revisit if this module is used externally -->
     <dependency>
-      <groupId>org.infinispan</groupId>
-      <artifactId>infinispan-embedded-query</artifactId>
-      <version>${version.org.infinispan.community}</version>
-      <scope>provided</scope>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-search-engine</artifactId>
     </dependency>
 
     <dependency>

--- a/hawkular-inventory-parent/hawkular-inventory-service/pom.xml
+++ b/hawkular-inventory-parent/hawkular-inventory-service/pom.xml
@@ -67,16 +67,36 @@
       <version>${project.version}</version>
     </dependency>
 
+    <!-- Infinispan/Hibernate Search deps -->
     <dependency>
       <groupId>org.infinispan</groupId>
-      <artifactId>infinispan-embedded</artifactId>
-      <version>${version.org.infinispan.community}</version>
+      <artifactId>infinispan-query</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.infinispan</groupId>
+          <artifactId>infinispan-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-search-engine</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.infinispan</groupId>
-      <artifactId>infinispan-embedded-query</artifactId>
-      <version>${version.org.infinispan.community}</version>
+      <artifactId>infinispan-core</artifactId>
+    </dependency>
+
+    <!-- infinispan-query 9.1.1 pulls the wrong version of deps. Override here (below) -->
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-search-engine</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-search-elasticsearch</artifactId>
     </dependency>
 
     <dependency>

--- a/hawkular-inventory-parent/pom.xml
+++ b/hawkular-inventory-parent/pom.xml
@@ -40,6 +40,32 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <!-- WildFly does not package the ispn versions we need. Override the wf bom versions
+           and make it explicit here what we want for ispn and hibernate search -->
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-query</artifactId>
+        <version>${version.org.infinispan.community}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-core</artifactId>
+        <version>${version.org.infinispan.community}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-search-engine</artifactId>
+        <version>${version.org.hibernate.search}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-search-elasticsearch</artifactId>
+        <version>${version.org.hibernate.search}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
     <version.org.assertj>3.6.1</version.org.assertj>
     <!-- Keep in sync with modules/system/layers/base/org/freemarker/main in the Keycloak or Hawkular Accounts feature pack -->
     <version.org.freemarker>2.3.23</version.org.freemarker>
+    <version.org.hibernate.search>5.8.0.Final</version.org.hibernate.search>
     <version.org.infinispan.community>9.1.1.Final</version.org.infinispan.community>
     <version.org.infinispan.product>8.5.0.Final</version.org.infinispan.product>
     <version.org.jboss.arquillian>1.1.11.Final</version.org.jboss.arquillian>


### PR DESCRIPTION
Convert from infinispan-embedded to standard infinispan and hibernate-search jars.  Note that there are some subtleties in the dependency-management to override the WF bom versions.