### PR TITLE
Fix ResourcePathResponse > ResourceResponse changes

### DIFF
--- a/hawkular-command-gateway/hawkular-command-gateway-api/src/main/java/org/hawkular/cmdgw/api/MessageUtils.java
+++ b/hawkular-command-gateway/hawkular-command-gateway-api/src/main/java/org/hawkular/cmdgw/api/MessageUtils.java
@@ -20,8 +20,9 @@ package org.hawkular.cmdgw.api;
  * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
  */
 public class MessageUtils {
-    public static void prepareResourcePathResponse(ResourceRequest request, ResourceResponse response) {
+    public static void prepareResourceResponse(ResourceRequest request, ResourceResponse response) {
         prepareUiSessionDestination((UiSessionOrigin) request, (UiSessionDestination) response);
+        response.setFeedId(request.getFeedId());
         response.setResourceId(request.getResourceId());
     }
     public static void prepareUiSessionDestination(UiSessionOrigin request, UiSessionDestination response) {

--- a/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/UpdateDatasourceResponse.schema.json
+++ b/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/UpdateDatasourceResponse.schema.json
@@ -2,7 +2,7 @@
   "type": "object",
   "extends": {
     "type": "object",
-    "javaType": "org.hawkular.cmdgw.api.ResourcePathResponse"
+    "javaType": "org.hawkular.cmdgw.api.ResourceResponse"
   },
   "javaType": "org.hawkular.cmdgw.api.UpdateDatasourceResponse",
   "description": "Results of an UpdateDatasourceRequest.",


### PR DESCRIPTION
@jmazzitelli, this fixes your reported bug

I think now is in good shape.

As you have seen, the main change is to remove the old inventory API and to change the ResourcePath* per Resource* instead to work with resourcePath and extract the relevant info, now the base is to use feedId and resourceId data.

I think it is reasonable, but let me know if any additional change is needed.