### PR TITLE
Replace children with parent in Resource model

### DIFF
--- a/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResourceNode.java
+++ b/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResourceNode.java
@@ -79,13 +79,13 @@ public class ResourceNode implements Serializable {
      */
     public static ResourceNode fromResource(Resource r,
                                      Function<String, ResourceType> rtLoader,
-                                     Function<String, Resource> rLoader) {
+                                     Function<String, List<Resource>> rLoader) {
         return fromResource(r, rtLoader, rLoader, new HashSet<>());
     }
 
     private static ResourceNode fromResource(Resource r,
                                              Function<String, ResourceType> rtLoader,
-                                             Function<String, Resource> rLoader,
+                                             Function<String, List<Resource>> rLoader,
                                              Set<String> loaded) {
         if (loaded.contains(r.getId())) {
             throw new IllegalStateException("Cycle detected in the tree with id " + r.getId()

--- a/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResourceWithType.java
+++ b/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResourceWithType.java
@@ -50,22 +50,17 @@ public class ResourceWithType implements Serializable {
     private final ResourceType type;
 
     @JsonInclude(Include.NON_NULL)
-    private final List<String> childrenIds;
-
-    @JsonInclude(Include.NON_NULL)
     private final List<Metric> metrics;
 
     public ResourceWithType(@JsonProperty("id") String id,
                             @JsonProperty("name") String name,
                             @JsonProperty("properties") Map<String, String> properties,
                             @JsonProperty("type") ResourceType type,
-                            @JsonProperty("childrenIds") List<String> childrenIds,
                             @JsonProperty("metrics") List<Metric> metrics) {
         this.id = id;
         this.name = name;
         this.properties = properties;
         this.type = type;
-        this.childrenIds = childrenIds;
         this.metrics = metrics;
     }
 
@@ -79,7 +74,7 @@ public class ResourceWithType implements Serializable {
     public static ResourceWithType fromResource(Resource r,
                                                 Function<String, ResourceType> rtLoader) {
         return new ResourceWithType(r.getId(), r.getName(), r.getProperties(), r.getType(rtLoader),
-                r.getChildrenIds(), r.getMetrics());
+                r.getMetrics());
     }
 
     public String getId() {
@@ -96,10 +91,6 @@ public class ResourceWithType implements Serializable {
 
     public ResourceType getType() {
         return type;
-    }
-
-    public List<String> getChildrenIds() {
-        return childrenIds;
     }
 
     public List<Metric> getMetrics() {

--- a/hawkular-inventory-parent/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/JsonTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/JsonTest.java
@@ -50,7 +50,7 @@ public class JsonTest {
                     new ArrayList<>(), new ArrayList<>());
             resources.add(resourceX);
             ResourceWithType resourceWTX = new ResourceWithType("Lbis" + i, "Largebis" + i, new HashMap<>(),
-                    fooType, new ArrayList<>(), new ArrayList<>());
+                    fooType, new ArrayList<>());
             resourcesWithType.add(resourceWTX);
             ResourceType resourceTypeX = new ResourceType("EAP" + i, new HashSet<>(), new HashMap<>());
             resourceTypes.add(resourceTypeX);

--- a/hawkular-inventory-parent/hawkular-inventory-model/src/test/java/org/hawkular/inventory/model/BuilderTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-model/src/test/java/org/hawkular/inventory/model/BuilderTest.java
@@ -66,9 +66,7 @@ public class BuilderTest {
                 .id("res.id")
                 .name("res.name")
                 .typeId("res.typeId")
-                .childId("res.childId1")
-                .childId("res.childId2")
-                .isRoot(true)
+                .parentId("res.parentId")
                 .property("res.prop1", "res.value1")
                 .property("res.prop2", "res.value2")
                 .metric(m)
@@ -85,10 +83,7 @@ public class BuilderTest {
         assertThat(r.getId()).isEqualTo("res.id");
         assertThat(r.getName()).isEqualTo("res.name");
         assertThat(r.getTypeId()).isEqualTo("res.typeId");
-        assertThat(r.getChildrenIds()).contains("res.childId1");
-        assertThat(r.getChildrenIds()).contains("res.childId2");
-        assertThat(r.getChildrenIds()).hasSize(2);
-        assertThat(r.isRoot()).isTrue();
+        assertThat(r.getParentId()).isEqualTo("res.parentId");
         assertThat(r.getProperties()).hasEntrySatisfying("res.prop1", v -> {
             assertThat(v).isEqualTo("res.value1");
         });

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryRestTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryRestTest.java
@@ -77,18 +77,18 @@ public class InventoryRestTest {
     private static final Metric METRIC4
             = new Metric("gc2", "GC", MetricUnit.NONE, new HashMap<>());
 
-    private static final Resource EAP1 = new Resource("EAP-1", "EAP-1", "feed1", "EAP", true,
-            Arrays.asList("child-1", "child-2"), Arrays.asList(METRIC1, METRIC2), new HashMap<>());
-    private static final Resource EAP2 = new Resource("EAP-2", "EAP-2", "feed2", "EAP", true,
-            Arrays.asList("child-3", "child-4"), Arrays.asList(METRIC3, METRIC4), new HashMap<>());
-    private static final Resource CHILD1 = new Resource("child-1", "Child 1", "feedX", "FOO", false,
-            new ArrayList<>(), new ArrayList<>(), new HashMap<>());
-    private static final Resource CHILD2 = new Resource("child-2", "Child 2", "feedX", "BAR", false,
-            new ArrayList<>(), new ArrayList<>(), new HashMap<>());
-    private static final Resource CHILD3 = new Resource("child-3", "Child 3", "feedX", "FOO", false,
-            new ArrayList<>(), new ArrayList<>(), new HashMap<>());
-    private static final Resource CHILD4 = new Resource("child-4", "Child 4", "feedX", "BAR", false,
-            new ArrayList<>(), new ArrayList<>(), new HashMap<>());
+    private static final Resource EAP1 = new Resource("EAP-1", "EAP-1", "feed1", "EAP", null,
+            Arrays.asList(METRIC1, METRIC2), new HashMap<>());
+    private static final Resource EAP2 = new Resource("EAP-2", "EAP-2", "feed2", "EAP", null,
+            Arrays.asList(METRIC3, METRIC4), new HashMap<>());
+    private static final Resource CHILD1 = new Resource("child-1", "Child 1", "feedX", "FOO", "EAP-1",
+            new ArrayList<>(), new HashMap<>());
+    private static final Resource CHILD2 = new Resource("child-2", "Child 2", "feedX", "BAR", "EAP-1",
+            new ArrayList<>(), new HashMap<>());
+    private static final Resource CHILD3 = new Resource("child-3", "Child 3", "feedX", "FOO", "EAP-2",
+            new ArrayList<>(), new HashMap<>());
+    private static final Resource CHILD4 = new Resource("child-4", "Child 4", "feedX", "BAR", "EAP-2",
+            new ArrayList<>(), new HashMap<>());
     private static final Map<String, Map<String, String>> RELOAD_PARAMETERS;
     static {
         RELOAD_PARAMETERS = new HashMap<>();
@@ -176,8 +176,8 @@ public class InventoryRestTest {
                 String childIdX = id + "-child-" + j;
                 String childNameX = "Child "+ j + " from " + id;
                 childrenIds.add(childIdX);
-                Resource childX = new Resource(childIdX, childNameX, feedX, childType, false,
-                        new ArrayList<>(), new ArrayList<>(), new HashMap<>());
+                Resource childX = new Resource(childIdX, childNameX, feedX, childType, id,
+                        new ArrayList<>(), new HashMap<>());
 
                 childrenResource.add(childX);
             }
@@ -194,8 +194,7 @@ public class InventoryRestTest {
                     name,
                     feedX,
                     typeId,
-                    true,
-                    childrenIds,
+                    null,
                     metricsResource,
                     propsX);
 
@@ -307,9 +306,6 @@ public class InventoryRestTest {
         assertThat(resources)
                 .extracting(ResourceWithType::getId)
                 .containsOnly("EAP-1", "EAP-2");
-        assertThat(resources)
-                .flatExtracting(ResourceWithType::getChildrenIds)
-                .containsOnly("child-1", "child-2", "child-3", "child-4");
     }
 
     @Test
@@ -410,10 +406,10 @@ public class InventoryRestTest {
 
     @Test
     public void test015_shouldFailOnDetectedCycle() {
-        Resource corruptedParent = new Resource("CP", "CP", "feedX", "FOO", true,
-                Collections.singletonList("CC"), new ArrayList<>(), new HashMap<>());
-        Resource corruptedChild = new Resource("CC", "CC", "feedX", "BAR", false,
-                Collections.singletonList("CP"), new ArrayList<>(), new HashMap<>());
+        Resource corruptedParent = new Resource("CP", "CP", "feedX", "FOO", "CC",
+                new ArrayList<>(), new HashMap<>());
+        Resource corruptedChild = new Resource("CC", "CC", "feedX", "BAR", "CP",
+                new ArrayList<>(), new HashMap<>());
         Import corruptedImport = new Import(Arrays.asList(corruptedParent, corruptedChild), null);
 
         Client client = ClientBuilder.newClient();

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryRestTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryRestTest.java
@@ -377,7 +377,7 @@ public class InventoryRestTest {
         ResourceNode tree = response.readEntity(ResourceNode.class);
         assertThat(tree.getChildren())
                 .extracting(ResourceNode::getId)
-                .containsExactly("child-1", "child-2");
+                .containsOnly("child-1", "child-2");
     }
 
     @Test

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryServiceIspnTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryServiceIspnTest.java
@@ -54,18 +54,18 @@ public class InventoryServiceIspnTest {
             = new Metric("memory2", "Memory", MetricUnit.BYTES, new HashMap<>());
     private static final Metric METRIC4
             = new Metric("gc2", "GC", MetricUnit.NONE, new HashMap<>());
-    private static final Resource EAP1 = new Resource("EAP-1", "EAP-1", "feed1", "EAP", true,
-            Arrays.asList("child-1", "child-2"), Arrays.asList(METRIC1, METRIC2), new HashMap<>());
-    private static final Resource EAP2 = new Resource("EAP-2", "EAP-2", "feed2", "EAP", true,
-            Arrays.asList("child-3", "child-4"), Arrays.asList(METRIC3, METRIC4), new HashMap<>());
-    private static final Resource CHILD1 = new Resource("child-1", "Child 1", "feedX", "FOO", false,
-            new ArrayList<>(), new ArrayList<>(), new HashMap<>());
-    private static final Resource CHILD2 = new Resource("child-2", "Child 2", "feedX", "BAR", false,
-            new ArrayList<>(), new ArrayList<>(), new HashMap<>());
-    private static final Resource CHILD3 = new Resource("child-3", "Child 3", "feedX", "FOO", false,
-            new ArrayList<>(), new ArrayList<>(), new HashMap<>());
-    private static final Resource CHILD4 = new Resource("child-4", "Child 4", "feedX", "BAR", false,
-            new ArrayList<>(), new ArrayList<>(), new HashMap<>());
+    private static final Resource EAP1 = new Resource("EAP-1", "EAP-1", "feed1", "EAP", null,
+            Arrays.asList(METRIC1, METRIC2), new HashMap<>());
+    private static final Resource EAP2 = new Resource("EAP-2", "EAP-2", "feed2", "EAP", null,
+            Arrays.asList(METRIC3, METRIC4), new HashMap<>());
+    private static final Resource CHILD1 = new Resource("child-1", "Child 1", "feedX", "FOO", "EAP-1",
+            new ArrayList<>(), new HashMap<>());
+    private static final Resource CHILD2 = new Resource("child-2", "Child 2", "feedX", "BAR", "EAP-1",
+            new ArrayList<>(), new HashMap<>());
+    private static final Resource CHILD3 = new Resource("child-3", "Child 3", "feedX", "FOO", "EAP-2",
+            new ArrayList<>(), new HashMap<>());
+    private static final Resource CHILD4 = new Resource("child-4", "Child 4", "feedX", "BAR", "EAP-2",
+            new ArrayList<>(), new HashMap<>());
     private static final Collection<Operation> EAP_OPS = Arrays.asList(
             new Operation("Reload", new HashMap<>()),
             new Operation("Shutdown", new HashMap<>()));
@@ -138,9 +138,6 @@ public class InventoryServiceIspnTest {
                 .extracting(ResourceWithType::getType)
                 .extracting(ResourceType::getId)
                 .containsOnly("EAP", "EAP");
-        assertThat(top)
-                .flatExtracting(ResourceWithType::getChildrenIds)
-                .containsOnly("child-1", "child-2", "child-3", "child-4");
     }
 
     @Test
@@ -174,7 +171,7 @@ public class InventoryServiceIspnTest {
         ResourceNode tree = service.getTree("EAP-1").orElseThrow(AssertionError::new);
         assertThat(tree.getChildren())
                 .extracting(ResourceNode::getId)
-                .containsExactly("child-1", "child-2");
+                .containsOnly("child-1", "child-2");
     }
 
     @Test
@@ -202,10 +199,10 @@ public class InventoryServiceIspnTest {
 
     @Test
     public void shouldFailOnDetectedCycle() {
-        Resource corruptedParent = new Resource("CP", "CP", "feedX", "FOO", true,
-                Collections.singletonList("CC"), new ArrayList<>(), new HashMap<>());
-        Resource corruptedChild = new Resource("CC", "CC", "feedX", "BAR", false,
-                Collections.singletonList("CP"), new ArrayList<>(), new HashMap<>());
+        Resource corruptedParent = new Resource("CP", "CP", "feedX", "FOO", "CC",
+                new ArrayList<>(), new HashMap<>());
+        Resource corruptedChild = new Resource("CC", "CC", "feedX", "BAR", "CP",
+                new ArrayList<>(), new HashMap<>());
         service.addResource(corruptedParent);
         service.addResource(corruptedChild);
 
@@ -270,8 +267,8 @@ public class InventoryServiceIspnTest {
         List<Resource> resources = new ArrayList<>();
         for (int j = 0; j < maxFeeds; j++) {
             for (int i = 0; i < maxItems; i++) {
-                Resource resourceX = new Resource("F" + j + "L" + i, "Large" + i, "feed" + j, "FOO", true,
-                        new ArrayList<>(), new ArrayList<>(), new HashMap<>());
+                Resource resourceX = new Resource("F" + j + "L" + i, "Large" + i, "feed" + j, "FOO", null,
+                        new ArrayList<>(), new HashMap<>());
                 resources.add(resourceX);
             }
             service.addResource(resources);


### PR DESCRIPTION
I listed some pros & cons about using parent versus children in model:

PRO:
- Easier update from the agent: when a resource is added or deleted, no need to search for its parent to update it too. Correctness of the tree not threatened.
- No need for "isRoot" field & index anymore.

CONS:
- Must be indexed to satisfy queries such as: "find all resources whose parent is xxx", typically to build subtree.
- Cannot get children ids from raw resource anymore. So they will not be visible either when getting a resource not in "tree" mode.
