### PR TITLE
Add export endpoint + split tests

### DIFF
--- a/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Inventory.java
+++ b/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Inventory.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @author Jay Shaughnessy
  * @author Lucas Ponce
  */
-public class Import implements Serializable {
+public class Inventory implements Serializable {
 
     @JsonInclude(Include.NON_NULL)
     private List<Resource> resources;
@@ -38,8 +38,8 @@ public class Import implements Serializable {
     @JsonInclude(Include.NON_NULL)
     private List<ResourceType> types;
 
-    public Import(@JsonProperty("resources") List<Resource> resources,
-                  @JsonProperty("types") List<ResourceType> types) {
+    public Inventory(@JsonProperty("resources") List<Resource> resources,
+                     @JsonProperty("types") List<ResourceType> types) {
         this.resources = resources;
         this.types = types;
     }
@@ -65,10 +65,10 @@ public class Import implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        Import anImport = (Import) o;
+        Inventory anInventory = (Inventory) o;
 
-        if (resources != null ? !resources.equals(anImport.resources) : anImport.resources != null) return false;
-        return types != null ? types.equals(anImport.types) : anImport.types == null;
+        if (resources != null ? !resources.equals(anInventory.resources) : anInventory.resources != null) return false;
+        return types != null ? types.equals(anInventory.types) : anInventory.types == null;
     }
 
     @Override
@@ -80,7 +80,7 @@ public class Import implements Serializable {
 
     @Override
     public String toString() {
-        return "Import{" +
+        return "Inventory{" +
                 "resources=" + resources +
                 ", types=" + types +
                 '}';

--- a/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/InventoryService.java
+++ b/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/InventoryService.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.inventory.api;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -120,5 +122,5 @@ public interface InventoryService {
      */
     boolean isRunning();
 
-    Import buildExport();
+    void buildExport(OutputStream os) throws IOException;
 }

--- a/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/InventoryService.java
+++ b/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/InventoryService.java
@@ -119,4 +119,6 @@ public interface InventoryService {
      * @return true is InventoryService is Up and Running
      */
     boolean isRunning();
+
+    Import buildExport();
 }

--- a/hawkular-inventory-parent/hawkular-inventory-service/pom.xml
+++ b/hawkular-inventory-parent/hawkular-inventory-service/pom.xml
@@ -67,6 +67,12 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.hawkular.commons</groupId>
+      <artifactId>hawkular-commons-utils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <!-- Infinispan/Hibernate Search deps -->
     <dependency>
       <groupId>org.infinispan</groupId>

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/handlers/InventoryHandlers.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/handlers/InventoryHandlers.java
@@ -61,6 +61,17 @@ public class InventoryHandlers {
      */
 
     @GET
+    @Path("/export")
+    @Produces(APPLICATION_JSON)
+    public Response exportInventory() {
+        try {
+            return ResponseUtil.ok(inventoryService.buildExport());
+        } catch (Exception e) {
+            return ResponseUtil.internalError(e);
+        }
+    }
+
+    @GET
     @Path("/get-inventory-config/{templateName}")
     @Produces(TEXT_PLAIN)
     public Response getAgentConfig(@PathParam("templateName") final String templateName) {

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/handlers/InventoryHandlers.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/handlers/InventoryHandlers.java
@@ -35,8 +35,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
 
-import org.hawkular.inventory.api.Import;
+import org.hawkular.inventory.api.Inventory;
 import org.hawkular.inventory.api.InventoryService;
 import org.hawkular.inventory.api.ResourceFilter;
 import org.hawkular.inventory.log.InventoryLoggers;
@@ -65,7 +66,8 @@ public class InventoryHandlers {
     @Produces(APPLICATION_JSON)
     public Response exportInventory() {
         try {
-            return ResponseUtil.ok(inventoryService.buildExport());
+            StreamingOutput streamingOutput = inventoryService::buildExport;
+            return ResponseUtil.ok(streamingOutput);
         } catch (Exception e) {
             return ResponseUtil.internalError(e);
         }
@@ -101,7 +103,7 @@ public class InventoryHandlers {
     @Path("/import")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
-    public Response importInventory(final Import inventory) {
+    public Response importInventory(final Inventory inventory) {
         try {
             if (inventory != null) {
                 inventoryService.addResource(inventory.getResources());

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryServiceIspn.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryServiceIspn.java
@@ -34,6 +34,7 @@ import javax.ejb.Local;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 
+import org.hawkular.inventory.api.Import;
 import org.hawkular.inventory.api.InventoryService;
 import org.hawkular.inventory.api.ResourceFilter;
 import org.hawkular.inventory.api.ResourceNode;
@@ -229,6 +230,17 @@ public class InventoryServiceIspn implements InventoryService {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public Import buildExport() {
+        List<ResourceType> types = qResourceType.from(ResourceType.class)
+                .build()
+                .list();
+        List<Resource> resources = qResource.from(Resource.class)
+                .build()
+                .list();
+        return new Import(resources, types);
     }
 
     private Optional<String> getConfig(String fileName) {

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryServiceIspn.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryServiceIspn.java
@@ -16,8 +16,12 @@
  */
 package org.hawkular.inventory.service;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,7 +38,7 @@ import javax.ejb.Local;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 
-import org.hawkular.inventory.api.Import;
+import org.hawkular.commons.json.JsonUtil;
 import org.hawkular.inventory.api.InventoryService;
 import org.hawkular.inventory.api.ResourceFilter;
 import org.hawkular.inventory.api.ResourceNode;
@@ -232,17 +236,6 @@ public class InventoryServiceIspn implements InventoryService {
         return false;
     }
 
-    @Override
-    public Import buildExport() {
-        List<ResourceType> types = qResourceType.from(ResourceType.class)
-                .build()
-                .list();
-        List<Resource> resources = qResource.from(Resource.class)
-                .build()
-                .list();
-        return new Import(resources, types);
-    }
-
     private Optional<String> getConfig(String fileName) {
         // TODO: maybe some defensive check against file traversal attack?
         //  Or check that "resourceType" is in a whitelist of types?
@@ -291,4 +284,53 @@ public class InventoryServiceIspn implements InventoryService {
         return c == null || c.isEmpty();
     }
 
+    @Override
+    public void buildExport(OutputStream os) throws IOException {
+        try (Writer writer = new BufferedWriter(new OutputStreamWriter(os))) {
+            writer.write("{\"types\":[\n");
+            int offset = 0;
+            boolean hasMore = true;
+            boolean first = true;
+            while (hasMore) {
+                List<ResourceType> batch = qResourceType.from(ResourceType.class)
+                        .maxResults(MAX_RESULTS)
+                        .startOffset(offset)
+                        .build()
+                        .list();
+                for (ResourceType rt : batch) {
+                    if (!first) {
+                        writer.write(",\n");
+                    } else {
+                        first = false;
+                    }
+                    writer.write(JsonUtil.toJson(rt) + "\n");
+                }
+                hasMore = batch.size() == MAX_RESULTS;
+                offset += MAX_RESULTS;
+            }
+            writer.write("],\"resources\":[\n");
+            hasMore = true;
+            first = true;
+            offset = 0;
+            while (hasMore) {
+                List<Resource> batch = qResource.from(Resource.class)
+                        .maxResults(MAX_RESULTS)
+                        .startOffset(offset)
+                        .build()
+                        .list();
+                for (Resource r : batch) {
+                    if (!first) {
+                        writer.write(",\n");
+                    } else {
+                        first = false;
+                    }
+                    writer.write(JsonUtil.toJson(r) + "\n");
+                }
+                hasMore = batch.size() == MAX_RESULTS;
+                offset += MAX_RESULTS;
+            }
+            writer.write("]}\n");
+            writer.flush();
+        }
+    }
 }

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryPerfTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryPerfTest.java
@@ -36,7 +36,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.hawkular.inventory.api.Import;
+import org.hawkular.inventory.api.Inventory;
 import org.hawkular.inventory.api.ResultSet;
 import org.hawkular.inventory.model.Metric;
 import org.hawkular.inventory.model.MetricUnit;
@@ -66,7 +66,7 @@ import org.junit.runners.MethodSorters;
 public class InventoryPerfTest {
     private final Logger log = Logger.getLogger(InventoryPerfTest.class);
 
-    public static Import createResourceTypes() {
+    public static Inventory createResourceTypes() {
         Map<String, Map<String, String>> reload;
         reload = new HashMap<>();
         reload.put("param1", new HashMap<>());
@@ -105,10 +105,10 @@ public class InventoryPerfTest {
 
         List<ResourceType> resourceTypes = Arrays.asList(eapType, jdgType);
 
-        return new Import(null, resourceTypes);
+        return new Inventory(null, resourceTypes);
     }
 
-    public static Import createLargeInventory(int from, int to, int children, int metrics) {
+    public static Inventory createLargeInventory(int from, int to, int children, int metrics) {
         List<Resource> resources = new ArrayList<>();
         for (int i = from; i < to; i++) {
             String typeId = (i % 2 == 0) ? "EAP" : "JDG";
@@ -148,7 +148,7 @@ public class InventoryPerfTest {
             resources.addAll(childrenResource);
         }
 
-        return new Import(resources, null);
+        return new Inventory(resources, null);
     }
 
     @ArquillianResource
@@ -193,7 +193,7 @@ public class InventoryPerfTest {
         WebTarget target = client.target(baseUrl.toString()).path("import");
         Response response = target
                 .request(MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.entity(Resources.IMPORT, MediaType.APPLICATION_JSON_TYPE));
+                .post(Entity.entity(Resources.INVENTORY, MediaType.APPLICATION_JSON_TYPE));
         assertEquals(200, response.getStatus());
     }
 

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryPerfTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryPerfTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.hawkular.inventory.api.Import;
+import org.hawkular.inventory.api.ResultSet;
+import org.hawkular.inventory.model.Metric;
+import org.hawkular.inventory.model.MetricUnit;
+import org.hawkular.inventory.model.Operation;
+import org.hawkular.inventory.model.Resource;
+import org.hawkular.inventory.model.ResourceType;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@RunWith(Arquillian.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@Category(Performance.class)
+public class InventoryPerfTest {
+    private final Logger log = Logger.getLogger(InventoryPerfTest.class);
+
+    public static Import createResourceTypes() {
+        Map<String, Map<String, String>> reload;
+        reload = new HashMap<>();
+        reload.put("param1", new HashMap<>());
+        reload.get("param1").put("type", "bool");
+        reload.get("param1").put("description", "Description of param1 for Reload op");
+        reload.put("param2", new HashMap<>());
+        reload.get("param2").put("type", "bool");
+        reload.get("param2").put("description", "Description of param2 for Reload op");
+
+        Map<String, Map<String, String>> shutdown;
+        shutdown = new HashMap<>();
+        shutdown.put("param1", new HashMap<>());
+        shutdown.get("param1").put("type", "bool");
+        shutdown.get("param1").put("description", "Description of param1 for Shutdown op");
+        shutdown.put("param2", new HashMap<>());
+        shutdown.get("param2").put("type", "bool");
+        shutdown.get("param2").put("description", "Description of param2 for Shutdown op");
+        Collection<Operation> eapOps = Arrays.asList(
+                new Operation("Reload", reload),
+                new Operation("Shutdown", shutdown),
+                new Operation("Start", Collections.emptyMap()));
+        ResourceType eapType = new ResourceType("EAP", eapOps, new HashMap<>());
+
+        Map<String, Map<String, String>> flush;
+        flush = new HashMap<>();
+        flush.put("param1", new HashMap<>());
+        flush.get("param1").put("type", "bool");
+        flush.get("param1").put("description", "Description of param1 for Flush op");
+        flush.put("param2", new HashMap<>());
+        flush.get("param2").put("type", "bool");
+        flush.get("param2").put("description", "Description of param2 for Flush op");
+        Collection<Operation> jdgOps = Arrays.asList(
+                new Operation("Flush", flush),
+                new Operation("Delete", Collections.emptyMap()));
+        ResourceType jdgType = new ResourceType("JDG", jdgOps, new HashMap<>());
+
+        List<ResourceType> resourceTypes = Arrays.asList(eapType, jdgType);
+
+        return new Import(null, resourceTypes);
+    }
+
+    public static Import createLargeInventory(int from, int to, int children, int metrics) {
+        List<Resource> resources = new ArrayList<>();
+        for (int i = from; i < to; i++) {
+            String typeId = (i % 2 == 0) ? "EAP" : "JDG";
+            String id = "Server-" + i;
+            String name = "Server " + typeId + " with Id " + id;
+            String feedX = "feedX";
+            List<Resource> childrenResource = new ArrayList<>();
+            List<String> childrenIds = new ArrayList<>();
+            for (int j = 0; j < children; j++) {
+                String childType = (j % 2 == 0) ? "FOO" : "BAR";
+                String childIdX = id + "-child-" + j;
+                String childNameX = "Child "+ j + " from " + id;
+                childrenIds.add(childIdX);
+                Resource childX = new Resource(childIdX, childNameX, feedX, childType, id,
+                        new ArrayList<>(), new HashMap<>());
+
+                childrenResource.add(childX);
+            }
+
+            List<Metric> metricsResource = new ArrayList<>();
+            for (int k = 0; k < metrics; k++) {
+                Metric metricX = new Metric("metric-" + k, "Metric " + k, MetricUnit.BYTES, new HashMap<>());
+                metricsResource.add(metricX);
+            }
+
+            Map<String, String> propsX = new HashMap<>();
+            propsX.put("description", "This is a description for " + id);
+            Resource serverX = new Resource(id,
+                    name,
+                    feedX,
+                    typeId,
+                    null,
+                    metricsResource,
+                    propsX);
+
+            resources.add(serverX);
+            resources.addAll(childrenResource);
+        }
+
+        return new Import(resources, null);
+    }
+
+    @ArquillianResource
+    private URL baseUrl;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        File[] libs = Maven.resolver()
+                .loadPomFromFile("pom.xml")
+                .importRuntimeDependencies()
+                .resolve()
+                .withTransitivity()
+                .asFile();
+        File[] assertj = Maven.resolver()
+                .loadPomFromFile("pom.xml")
+                .resolve("org.assertj:assertj-core")
+                .withTransitivity()
+                .asFile();
+        return ShrinkWrap.create(WebArchive.class)
+                .addPackages(true, "org.hawkular.inventory")
+                .addAsLibraries(libs)
+                .addAsLibraries(assertj)
+                .setWebXML(new File("src/main/webapp/WEB-INF/web.xml"))
+                .addAsResource(new File("src/main/resources/hawkular-inventory-ispn.xml"))
+                .addAsResource(new File("src/main/resources/wildfly-10-jmx-exporter.yml"))
+                .addAsWebInfResource(new File("src/main/webapp/WEB-INF/beans.xml"));
+    }
+
+    @Test
+    public void test000_statusIsUp() {
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target(baseUrl.toString()).path("status");
+        Response response = target
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get();
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void test001_importResources() {
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target(baseUrl.toString()).path("import");
+        Response response = target
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .post(Entity.entity(Resources.IMPORT, MediaType.APPLICATION_JSON_TYPE));
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void test002_largeImport() {
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target(baseUrl.toString()).path("import");
+        Response response = target
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .post(Entity.entity(createResourceTypes(), MediaType.APPLICATION_JSON_TYPE));
+        assertEquals(200, response.getStatus());
+
+        int maxIterations = 50;
+        int maxServersPerIteration = 100;
+        int childrenPerServer = 100;
+        int metricsPerServer = 20;
+
+        for (int i = 0; i < maxIterations; i++) {
+            int from = i * maxServersPerIteration;
+            int to = ((i + 1) * maxServersPerIteration) - 1;
+            client = ClientBuilder.newClient();
+            target = client.target(baseUrl.toString()).path("import");
+            response = target
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .post(Entity.entity(createLargeInventory(from, to, childrenPerServer, metricsPerServer), MediaType.APPLICATION_JSON_TYPE));
+            assertEquals(200, response.getStatus());
+            int mod = maxIterations > 500 ? 100 : 10;
+            if ( i % mod == 0) {
+                log.infof("Creating [%s] Servers", (i * maxServersPerIteration));
+            }
+        }
+        log.infof("Final - Created [%s] Servers", (maxIterations * maxServersPerIteration));
+
+        log.infof("Fetch top resources");
+        for (int i = 0; i < maxIterations; i++) {
+            client = ClientBuilder.newClient();
+            target = client.target(baseUrl.toString())
+                    .path("resources")
+                    .queryParam("root", true)
+                    .queryParam("maxResults", maxServersPerIteration)
+                    .queryParam("startOffset", i * maxServersPerIteration);
+            response = target
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .get();
+            assertEquals(200, response.getStatus());
+            int mod = maxIterations > 500 ? 100 : 10;
+            if ( i % mod == 0) {
+                log.infof("Querying [%s] Servers", (i * maxServersPerIteration));
+            }
+        }
+
+        log.info("Querying all types");
+        client = ClientBuilder.newClient();
+        target = client.target(baseUrl.toString()).path("types");
+        response = target
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .get();
+        assertEquals(200, response.getStatus());
+        assertThat((List<ResourceType>) response.readEntity(ResultSet.class).getResults())
+                .extracting(ResourceType::getId)
+                .containsOnly("EAP", "FOO", "BAR", "JDG");
+    }
+
+    @Test
+    public void test003_shouldGetResourceTypesAndNotImpactFromResources() {
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target(baseUrl.toString()).path("types");
+        Response response = target
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .get();
+        assertEquals(200, response.getStatus());
+        assertThat((List<ResourceType>) response.readEntity(ResultSet.class).getResults())
+                .extracting(ResourceType::getId)
+                .containsOnly("EAP", "FOO", "BAR", "JDG");
+    }
+
+    @Test
+    public void zzz_clean() {
+        // FIXME: proper way for "AfterClass" with arquillian given there's non-static stuff needed?
+        // Delete resources
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target(baseUrl.toString());
+        target.path("type/JDG").request().delete().close();
+    }
+}

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryRestTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryRestTest.java
@@ -23,8 +23,6 @@ import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,21 +39,16 @@ import org.hawkular.inventory.api.Import;
 import org.hawkular.inventory.api.ResourceNode;
 import org.hawkular.inventory.api.ResourceWithType;
 import org.hawkular.inventory.api.ResultSet;
-import org.hawkular.inventory.model.Metric;
-import org.hawkular.inventory.model.MetricUnit;
-import org.hawkular.inventory.model.Operation;
 import org.hawkular.inventory.model.Resource;
 import org.hawkular.inventory.model.ResourceType;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
 
@@ -66,144 +59,6 @@ import org.junit.runners.MethodSorters;
 @RunWith(Arquillian.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class InventoryRestTest {
-    private final Logger log = Logger.getLogger(InventoryRestTest.class);
-
-    private static final Metric METRIC1
-            = new Metric("memory1", "Memory", MetricUnit.BYTES, new HashMap<>());
-    private static final Metric METRIC2
-            = new Metric("gc1", "GC", MetricUnit.NONE, new HashMap<>());
-    private static final Metric METRIC3
-            = new Metric("memory2", "Memory", MetricUnit.BYTES, new HashMap<>());
-    private static final Metric METRIC4
-            = new Metric("gc2", "GC", MetricUnit.NONE, new HashMap<>());
-
-    private static final Resource EAP1 = new Resource("EAP-1", "EAP-1", "feed1", "EAP", null,
-            Arrays.asList(METRIC1, METRIC2), new HashMap<>());
-    private static final Resource EAP2 = new Resource("EAP-2", "EAP-2", "feed2", "EAP", null,
-            Arrays.asList(METRIC3, METRIC4), new HashMap<>());
-    private static final Resource CHILD1 = new Resource("child-1", "Child 1", "feedX", "FOO", "EAP-1",
-            new ArrayList<>(), new HashMap<>());
-    private static final Resource CHILD2 = new Resource("child-2", "Child 2", "feedX", "BAR", "EAP-1",
-            new ArrayList<>(), new HashMap<>());
-    private static final Resource CHILD3 = new Resource("child-3", "Child 3", "feedX", "FOO", "EAP-2",
-            new ArrayList<>(), new HashMap<>());
-    private static final Resource CHILD4 = new Resource("child-4", "Child 4", "feedX", "BAR", "EAP-2",
-            new ArrayList<>(), new HashMap<>());
-    private static final Map<String, Map<String, String>> RELOAD_PARAMETERS;
-    static {
-        RELOAD_PARAMETERS = new HashMap<>();
-        RELOAD_PARAMETERS.put("param1", new HashMap<>());
-        RELOAD_PARAMETERS.get("param1").put("type", "bool");
-        RELOAD_PARAMETERS.get("param1").put("description", "Description of param1 for Reload op");
-        RELOAD_PARAMETERS.put("param2", new HashMap<>());
-        RELOAD_PARAMETERS.get("param2").put("type", "bool");
-        RELOAD_PARAMETERS.get("param2").put("description", "Description of param2 for Reload op");
-    }
-    private static final Map<String, Map<String, String>> SHUTDOWN_PARAMETERS;
-    static {
-        SHUTDOWN_PARAMETERS = new HashMap<>();
-        SHUTDOWN_PARAMETERS.put("param1", new HashMap<>());
-        SHUTDOWN_PARAMETERS.get("param1").put("type", "bool");
-        SHUTDOWN_PARAMETERS.get("param1").put("description", "Description of param1 for Shutdown op");
-        SHUTDOWN_PARAMETERS.put("param2", new HashMap<>());
-        SHUTDOWN_PARAMETERS.get("param2").put("type", "bool");
-        SHUTDOWN_PARAMETERS.get("param2").put("description", "Description of param2 for Shutdown op");
-    }
-    private static final Collection<Operation> EAP_OPS = Arrays.asList(
-            new Operation("Reload", RELOAD_PARAMETERS),
-            new Operation("Shutdown", SHUTDOWN_PARAMETERS),
-            new Operation("Start", Collections.emptyMap()));
-    private static final ResourceType TYPE_EAP = new ResourceType("EAP", EAP_OPS, new HashMap<>());
-    private static final ResourceType TYPE_FOO = new ResourceType("FOO", Collections.emptyList(), new HashMap<>());
-    private static final ResourceType TYPE_BAR = new ResourceType("BAR", Collections.emptyList(), new HashMap<>());
-
-    private static final Import IMPORT = new Import(Arrays.asList(EAP1, EAP2, CHILD1, CHILD2, CHILD3, CHILD4),
-            Arrays.asList(TYPE_EAP, TYPE_FOO, TYPE_BAR));
-
-    public static Import createResourceTypes() {
-        Map<String, Map<String, String>> reload;
-        reload = new HashMap<>();
-        reload.put("param1", new HashMap<>());
-        reload.get("param1").put("type", "bool");
-        reload.get("param1").put("description", "Description of param1 for Reload op");
-        reload.put("param2", new HashMap<>());
-        reload.get("param2").put("type", "bool");
-        reload.get("param2").put("description", "Description of param2 for Reload op");
-
-        Map<String, Map<String, String>> shutdown;
-        shutdown = new HashMap<>();
-        shutdown.put("param1", new HashMap<>());
-        shutdown.get("param1").put("type", "bool");
-        shutdown.get("param1").put("description", "Description of param1 for Shutdown op");
-        shutdown.put("param2", new HashMap<>());
-        shutdown.get("param2").put("type", "bool");
-        shutdown.get("param2").put("description", "Description of param2 for Shutdown op");
-        Collection<Operation> eapOps = Arrays.asList(
-                new Operation("Reload", reload),
-                new Operation("Shutdown", shutdown),
-                new Operation("Start", Collections.emptyMap()));
-        ResourceType eapType = new ResourceType("EAP", eapOps, new HashMap<>());
-
-        Map<String, Map<String, String>> flush;
-        flush = new HashMap<>();
-        flush.put("param1", new HashMap<>());
-        flush.get("param1").put("type", "bool");
-        flush.get("param1").put("description", "Description of param1 for Flush op");
-        flush.put("param2", new HashMap<>());
-        flush.get("param2").put("type", "bool");
-        flush.get("param2").put("description", "Description of param2 for Flush op");
-        Collection<Operation> jdgOps = Arrays.asList(
-                new Operation("Flush", flush),
-                new Operation("Delete", Collections.emptyMap()));
-        ResourceType jdgType = new ResourceType("JDG", jdgOps, new HashMap<>());
-
-        List<ResourceType> resourceTypes = Arrays.asList(eapType, jdgType);
-
-        return new Import(null, resourceTypes);
-    }
-
-    public static Import createLargeInventory(int from, int to, int children, int metrics) {
-        List<Resource> resources = new ArrayList<>();
-        for (int i = from; i < to; i++) {
-            String typeId = (i % 2 == 0) ? "EAP" : "JDG";
-            String id = "Server-" + i;
-            String name = "Server " + typeId + " with Id " + id;
-            String feedX = "feedX";
-            List<Resource> childrenResource = new ArrayList<>();
-            List<String> childrenIds = new ArrayList<>();
-            for (int j = 0; j < children; j++) {
-                String childType = (j % 2 == 0) ? "FOO" : "BAR";
-                String childIdX = id + "-child-" + j;
-                String childNameX = "Child "+ j + " from " + id;
-                childrenIds.add(childIdX);
-                Resource childX = new Resource(childIdX, childNameX, feedX, childType, id,
-                        new ArrayList<>(), new HashMap<>());
-
-                childrenResource.add(childX);
-            }
-
-            List<Metric> metricsResource = new ArrayList<>();
-            for (int k = 0; k < metrics; k++) {
-                Metric metricX = new Metric("metric-" + k, "Metric " + k, MetricUnit.BYTES, new HashMap<>());
-                metricsResource.add(metricX);
-            }
-
-            Map<String, String> propsX = new HashMap<>();
-            propsX.put("description", "This is a description for " + id);
-            Resource serverX = new Resource(id,
-                    name,
-                    feedX,
-                    typeId,
-                    null,
-                    metricsResource,
-                    propsX);
-
-            resources.add(serverX);
-            resources.addAll(childrenResource);
-        }
-
-        return new Import(resources, null);
-    }
 
     @ArquillianResource
     private URL baseUrl;
@@ -247,7 +102,7 @@ public class InventoryRestTest {
         WebTarget target = client.target(baseUrl.toString()).path("import");
         Response response = target
                 .request(MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.entity(IMPORT, MediaType.APPLICATION_JSON_TYPE));
+                .post(Entity.entity(Resources.IMPORT, MediaType.APPLICATION_JSON_TYPE));
         assertEquals(200, response.getStatus());
     }
 
@@ -461,84 +316,6 @@ public class InventoryRestTest {
     }
 
     @Test
-    @Category(Performance.class)
-    public void test018_largeImport() {
-        Client client = ClientBuilder.newClient();
-        WebTarget target = client.target(baseUrl.toString()).path("import");
-        Response response = target
-                .request(MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.entity(createResourceTypes(), MediaType.APPLICATION_JSON_TYPE));
-        assertEquals(200, response.getStatus());
-
-        int maxIterations = 50;
-        int maxServersPerIteration = 100;
-        int childrenPerServer = 100;
-        int metricsPerServer = 20;
-
-        for (int i = 0; i < maxIterations; i++) {
-            int from = i * maxServersPerIteration;
-            int to = ((i + 1) * maxServersPerIteration) - 1;
-            client = ClientBuilder.newClient();
-            target = client.target(baseUrl.toString()).path("import");
-            response = target
-                    .request(MediaType.APPLICATION_JSON_TYPE)
-                    .post(Entity.entity(createLargeInventory(from, to, childrenPerServer, metricsPerServer), MediaType.APPLICATION_JSON_TYPE));
-            assertEquals(200, response.getStatus());
-            int mod = maxIterations > 500 ? 100 : 10;
-            if ( i % mod == 0) {
-                log.infof("Creating [%s] Servers", (i * maxServersPerIteration));
-            }
-        }
-        log.infof("Final - Created [%s] Servers", (maxIterations * maxServersPerIteration));
-
-        log.infof("Fetch top resources");
-        for (int i = 0; i < maxIterations; i++) {
-            client = ClientBuilder.newClient();
-            target = client.target(baseUrl.toString())
-                    .path("resources")
-                    .queryParam("root", true)
-                    .queryParam("maxResults", maxServersPerIteration)
-                    .queryParam("startOffset", i * maxServersPerIteration);
-            response = target
-                    .request(MediaType.APPLICATION_JSON_TYPE)
-                    .accept(MediaType.APPLICATION_JSON_TYPE)
-                    .get();
-            assertEquals(200, response.getStatus());
-            int mod = maxIterations > 500 ? 100 : 10;
-            if ( i % mod == 0) {
-                log.infof("Querying [%s] Servers", (i * maxServersPerIteration));
-            }
-        }
-
-        log.info("Querying all types");
-        client = ClientBuilder.newClient();
-        target = client.target(baseUrl.toString()).path("types");
-        response = target
-                .request(MediaType.APPLICATION_JSON_TYPE)
-                .accept(MediaType.APPLICATION_JSON_TYPE)
-                .get();
-        assertEquals(200, response.getStatus());
-        assertThat((List<ResourceType>) response.readEntity(ResultSet.class).getResults())
-                .extracting(ResourceType::getId)
-                .containsOnly("EAP", "FOO", "BAR", "JDG");
-    }
-
-    @Test
-    @Category(Performance.class)
-    public void test019_shouldGetResourceTypesAndNotImpactFromResources() {
-        Client client = ClientBuilder.newClient();
-        WebTarget target = client.target(baseUrl.toString()).path("types");
-        Response response = target
-                .request(MediaType.APPLICATION_JSON_TYPE)
-                .accept(MediaType.APPLICATION_JSON_TYPE)
-                .get();
-        assertEquals(200, response.getStatus());
-        assertThat((List<ResourceType>) response.readEntity(ResultSet.class).getResults())
-                .extracting(ResourceType::getId)
-                .containsOnly("EAP", "FOO", "BAR", "JDG");
-    }
-
-    @Test
     public void test020_shouldGetAllEAPsPerFeed() {
         Client client = ClientBuilder.newClient();
         WebTarget target = client.target(baseUrl.toString()).path("resources")
@@ -568,11 +345,17 @@ public class InventoryRestTest {
     }
 
     @Test
-    public void zzz_clean() {
-        // FIXME: proper way for "AfterClass" with arquillian given there's non-static stuff needed?
-        // Delete resources
+    public void test021_shouldGetExport() {
         Client client = ClientBuilder.newClient();
-        WebTarget target = client.target(baseUrl.toString());
-        target.path("type/JDG").request().delete().close();
+        WebTarget target = client.target(baseUrl.toString()).path("export");
+        Response response = target
+                .request(MediaType.APPLICATION_JSON)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        Import imp = response.readEntity(Import.class);
+        assertThat(imp).isNotNull();
+        assertThat(imp.getResources()).extracting(Resource::getId).containsOnly("EAP-1", "EAP-2", "child-1",
+                "child-2", "child-3", "child-4", "CC", "CP");
+        assertThat(imp.getTypes()).extracting(ResourceType::getId).containsOnly("EAP", "FOO", "BAR");
     }
 }

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryRestTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryRestTest.java
@@ -35,7 +35,7 @@ import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.hawkular.inventory.api.Import;
+import org.hawkular.inventory.api.Inventory;
 import org.hawkular.inventory.api.ResourceNode;
 import org.hawkular.inventory.api.ResourceWithType;
 import org.hawkular.inventory.api.ResultSet;
@@ -102,7 +102,7 @@ public class InventoryRestTest {
         WebTarget target = client.target(baseUrl.toString()).path("import");
         Response response = target
                 .request(MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.entity(Resources.IMPORT, MediaType.APPLICATION_JSON_TYPE));
+                .post(Entity.entity(Resources.INVENTORY, MediaType.APPLICATION_JSON_TYPE));
         assertEquals(200, response.getStatus());
     }
 
@@ -265,13 +265,13 @@ public class InventoryRestTest {
                 new ArrayList<>(), new HashMap<>());
         Resource corruptedChild = new Resource("CC", "CC", "feedX", "BAR", "CP",
                 new ArrayList<>(), new HashMap<>());
-        Import corruptedImport = new Import(Arrays.asList(corruptedParent, corruptedChild), null);
+        Inventory corruptedInventory = new Inventory(Arrays.asList(corruptedParent, corruptedChild), null);
 
         Client client = ClientBuilder.newClient();
         WebTarget target = client.target(baseUrl.toString()).path("import");
         Response response = target
                 .request(MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.entity(corruptedImport, MediaType.APPLICATION_JSON_TYPE));
+                .post(Entity.entity(corruptedInventory, MediaType.APPLICATION_JSON_TYPE));
         assertEquals(200, response.getStatus());
         client.close();
 
@@ -352,7 +352,7 @@ public class InventoryRestTest {
                 .request(MediaType.APPLICATION_JSON)
                 .get();
         assertThat(response.getStatus()).isEqualTo(200);
-        Import imp = response.readEntity(Import.class);
+        Inventory imp = response.readEntity(Inventory.class);
         assertThat(imp).isNotNull();
         assertThat(imp.getResources()).extracting(Resource::getId).containsOnly("EAP-1", "EAP-2", "child-1",
                 "child-2", "child-3", "child-4", "CC", "CP");

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/Resources.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/Resources.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hawkular.inventory.api.Import;
+import org.hawkular.inventory.model.Metric;
+import org.hawkular.inventory.model.MetricUnit;
+import org.hawkular.inventory.model.Operation;
+import org.hawkular.inventory.model.Resource;
+import org.hawkular.inventory.model.ResourceType;
+
+/**
+ * @author Joel Takvorian
+ */
+public final class Resources {
+
+    static final Metric METRIC1
+            = new Metric("memory1", "Memory", MetricUnit.BYTES, new HashMap<>());
+    static final Metric METRIC2
+            = new Metric("gc1", "GC", MetricUnit.NONE, new HashMap<>());
+    static final Metric METRIC3
+            = new Metric("memory2", "Memory", MetricUnit.BYTES, new HashMap<>());
+    static final Metric METRIC4
+            = new Metric("gc2", "GC", MetricUnit.NONE, new HashMap<>());
+
+    static final Resource EAP1 = new Resource("EAP-1", "EAP-1", "feed1", "EAP", null,
+            Arrays.asList(METRIC1, METRIC2), new HashMap<>());
+    static final Resource EAP2 = new Resource("EAP-2", "EAP-2", "feed2", "EAP", null,
+            Arrays.asList(METRIC3, METRIC4), new HashMap<>());
+    static final Resource CHILD1 = new Resource("child-1", "Child 1", "feedX", "FOO", "EAP-1",
+            new ArrayList<>(), new HashMap<>());
+    static final Resource CHILD2 = new Resource("child-2", "Child 2", "feedX", "BAR", "EAP-1",
+            new ArrayList<>(), new HashMap<>());
+    static final Resource CHILD3 = new Resource("child-3", "Child 3", "feedX", "FOO", "EAP-2",
+            new ArrayList<>(), new HashMap<>());
+    static final Resource CHILD4 = new Resource("child-4", "Child 4", "feedX", "BAR", "EAP-2",
+            new ArrayList<>(), new HashMap<>());
+    static final Map<String, Map<String, String>> RELOAD_PARAMETERS;
+    static {
+        RELOAD_PARAMETERS = new HashMap<>();
+        RELOAD_PARAMETERS.put("param1", new HashMap<>());
+        RELOAD_PARAMETERS.get("param1").put("type", "bool");
+        RELOAD_PARAMETERS.get("param1").put("description", "Description of param1 for Reload op");
+        RELOAD_PARAMETERS.put("param2", new HashMap<>());
+        RELOAD_PARAMETERS.get("param2").put("type", "bool");
+        RELOAD_PARAMETERS.get("param2").put("description", "Description of param2 for Reload op");
+    }
+    static final Map<String, Map<String, String>> SHUTDOWN_PARAMETERS;
+    static {
+        SHUTDOWN_PARAMETERS = new HashMap<>();
+        SHUTDOWN_PARAMETERS.put("param1", new HashMap<>());
+        SHUTDOWN_PARAMETERS.get("param1").put("type", "bool");
+        SHUTDOWN_PARAMETERS.get("param1").put("description", "Description of param1 for Shutdown op");
+        SHUTDOWN_PARAMETERS.put("param2", new HashMap<>());
+        SHUTDOWN_PARAMETERS.get("param2").put("type", "bool");
+        SHUTDOWN_PARAMETERS.get("param2").put("description", "Description of param2 for Shutdown op");
+    }
+    static final Collection<Operation> EAP_OPS = Arrays.asList(
+            new Operation("Reload", RELOAD_PARAMETERS),
+            new Operation("Shutdown", SHUTDOWN_PARAMETERS),
+            new Operation("Start", Collections.emptyMap()));
+    static final ResourceType TYPE_EAP = new ResourceType("EAP", EAP_OPS, new HashMap<>());
+    static final ResourceType TYPE_FOO = new ResourceType("FOO", Collections.emptyList(), new HashMap<>());
+    static final ResourceType TYPE_BAR = new ResourceType("BAR", Collections.emptyList(), new HashMap<>());
+
+    static final Import IMPORT = new Import(Arrays.asList(EAP1, EAP2, CHILD1, CHILD2, CHILD3, CHILD4),
+            Arrays.asList(TYPE_EAP, TYPE_FOO, TYPE_BAR));
+
+    private Resources() {
+    }
+}

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/Resources.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/Resources.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.hawkular.inventory.api.Import;
+import org.hawkular.inventory.api.Inventory;
 import org.hawkular.inventory.model.Metric;
 import org.hawkular.inventory.model.MetricUnit;
 import org.hawkular.inventory.model.Operation;
@@ -84,7 +84,7 @@ public final class Resources {
     static final ResourceType TYPE_FOO = new ResourceType("FOO", Collections.emptyList(), new HashMap<>());
     static final ResourceType TYPE_BAR = new ResourceType("BAR", Collections.emptyList(), new HashMap<>());
 
-    static final Import IMPORT = new Import(Arrays.asList(EAP1, EAP2, CHILD1, CHILD2, CHILD3, CHILD4),
+    static final Inventory INVENTORY = new Inventory(Arrays.asList(EAP1, EAP2, CHILD1, CHILD2, CHILD3, CHILD4),
             Arrays.asList(TYPE_EAP, TYPE_FOO, TYPE_BAR));
 
     private Resources() {

--- a/hawkular-inventory-parent/pom.xml
+++ b/hawkular-inventory-parent/pom.xml
@@ -66,6 +66,7 @@
         <artifactId>hibernate-search-elasticsearch</artifactId>
         <version>${version.org.hibernate.search}</version>
       </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -53,5 +53,15 @@
       <artifactId>jboss-logging-processor</artifactId>
       <version>${version.org.jboss.logging.jboss-logging-tools}</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${version.com.fasterxml.jackson.core}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${version.com.fasterxml.jackson.core}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/utils/src/main/java/org/hawkular/commons/json/JsonUtil.java
+++ b/utils/src/main/java/org/hawkular/commons/json/JsonUtil.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.commons.json;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Json serialization/deserialization utility using Jackson implementation.
+ *
+ * @author Lucas Ponce
+ * @author Joel Takvorian
+ */
+public final class JsonUtil {
+
+    private static ObjectMapper MAPPER = new ObjectMapper();
+
+    private JsonUtil() {
+    }
+
+    public static String toJson(Object resource) {
+        try {
+            return MAPPER.writeValueAsString(resource);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static <T> List<T> listFromJson(String json, Class<T> clazz) {
+        try {
+            return MAPPER.readValue(json, MAPPER.getTypeFactory().constructCollectionType(List.class, clazz));
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static <T> T fromJson(String json, Class<T> clazz) {
+        try {
+            return MAPPER.readValue(json, clazz);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> getMap(Object o) {
+        return MAPPER.convertValue(o, Map.class);
+    }
+
+    public static ObjectMapper getMapper() {
+        return MAPPER;
+    }
+}

--- a/utils/src/main/java/org/hawkular/commons/json/JsonUtil.java
+++ b/utils/src/main/java/org/hawkular/commons/json/JsonUtil.java
@@ -17,9 +17,13 @@
 package org.hawkular.commons.json;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -67,5 +71,11 @@ public final class JsonUtil {
 
     public static ObjectMapper getMapper() {
         return MAPPER;
+    }
+
+    public static JsonGenerator createJsonGenerator(OutputStream os) throws IOException {
+        JsonGenerator jsonGen = new JsonFactory().createGenerator(os, JsonEncoding.UTF8);
+        jsonGen.setCodec(MAPPER);
+        return jsonGen;
     }
 }


### PR DESCRIPTION
In the same time, refactor tests to separate perf & rest tests so that "export" is not run after perf tests.
New common file for test resources definitions