### PR TITLE
Add Service to just get direct child resources of a parent.

### DIFF
--- a/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/InventoryService.java
+++ b/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/InventoryService.java
@@ -86,6 +86,22 @@ public interface InventoryService {
     ResultSet<ResourceWithType> getResources(ResourceFilter filter, long startOffset, int maxResults);
 
     /**
+     * Get a list of of child resources for a parent resource, with default pagination
+     * @param parentId resourceId of the parent resource
+     * @return resources embedded in page object {@link ResultSet}
+     */
+    ResultSet<ResourceWithType> getChildren(String parentId);
+
+    /**
+     * Get a list of child resources for a parent resource, with the provided pagination options
+     * @param parentId resourceId of the parent resource
+     * @param startOffset pagination offset
+     * @param maxResults pagination number of results
+     * @return resources embedded in page object {@link ResultSet}
+     */
+    ResultSet<ResourceWithType> getChildren(String parentId, long startOffset, int maxResults);
+
+    /**
      * Get resource types with the default pagination options (first 100 results)
      * @return resource types embedded in page object {@link ResultSet}
      */

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/handlers/InventoryHandlers.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/handlers/InventoryHandlers.java
@@ -156,6 +156,19 @@ public class InventoryHandlers {
     }
 
     @GET
+    @Path("/resources/{id}/children")
+    @Produces(APPLICATION_JSON)
+    public Response getChildren(@PathParam("id") final String id,
+                                @DefaultValue("0") @QueryParam("startOffSet") final Long startOffset,
+                                @DefaultValue("100") @QueryParam("maxResults") final Integer maxResults) {
+        try {
+            return ResponseUtil.ok(inventoryService.getChildren(id, startOffset, maxResults));
+        } catch (Exception e) {
+            return ResponseUtil.internalError(e);
+        }
+    }
+
+    @GET
     @Path("/types")
     @Produces(APPLICATION_JSON)
     public Response getAllResourceTypes(@DefaultValue("0") @QueryParam("startOffSet") final Long startOffset,

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryServiceIspn.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryServiceIspn.java
@@ -254,6 +254,23 @@ public class InventoryServiceIspn implements InventoryService {
         }
     }
 
+    @Override
+    public ResultSet<ResourceWithType> getChildren(String parentId) {
+        return getChildren(parentId, 0, MAX_RESULTS);
+    }
+
+    @Override
+    public ResultSet<ResourceWithType> getChildren(String parentId, long startOffset, int maxResults) {
+        Query query = qResource.from(Resource.class)
+                .having("parentId").equal(parentId)
+                .maxResults(maxResults)
+                .startOffset(startOffset).build();
+        List<ResourceWithType> result = query.list().stream()
+                .map(r -> ResourceWithType.fromResource((Resource) r, this::getNullableResourceType))
+                .collect(Collectors.toList());
+        return new ResultSet<>(result, (long) query.getResultSize(), startOffset);
+    }
+
     private List<Resource> getResourcesForParent(String parentId) {
         if (isEmpty(parentId)) {
             return Collections.emptyList();

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryRestTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryRestTest.java
@@ -405,6 +405,20 @@ public class InventoryRestTest {
     }
 
     @Test
+    public void test012_shouldGetOnlyChildren() {
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target(baseUrl.toString()).path("resources/EAP-1/children");
+        Response response = target
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .get();
+        assertEquals(200, response.getStatus());
+        assertThat((List<ResourceWithType>) response.readEntity(ResultSet.class).getResults())
+                .extracting(ResourceWithType::getId)
+                .containsOnly("child-1", "child-2");
+    }
+
+    @Test
     public void test015_shouldFailOnDetectedCycle() {
         Resource corruptedParent = new Resource("CP", "CP", "feedX", "FOO", "CC",
                 new ArrayList<>(), new HashMap<>());

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryServiceIspnTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryServiceIspnTest.java
@@ -168,6 +168,13 @@ public class InventoryServiceIspnTest {
     }
 
     @Test
+    public void shouldGetOnlyChildren() {
+        assertThat(service.getChildren("EAP-1").getResults())
+                .extracting(ResourceWithType::getId)
+                .containsOnly("child-1", "child-2");
+    }
+
+    @Test
     public void shouldGetChildren() {
         ResourceNode tree = service.getTree("EAP-1").orElseThrow(AssertionError::new);
         assertThat(tree.getChildren())


### PR DESCRIPTION
 I know there is already getTree but this helps the UI expand a tree incrementally, and I think it is generally useful to retrieve only immediate children.

@jotak Please review, thanks.