### PR TITLE
Inmutable objects in backend and fixes in performance tests

### DIFF
--- a/hawkular-inventory-parent/hawkular-inventory-model/pom.xml
+++ b/hawkular-inventory-parent/hawkular-inventory-model/pom.xml
@@ -33,11 +33,6 @@
   <dependencies>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-search-engine</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <scope>provided</scope>

--- a/hawkular-inventory-parent/hawkular-inventory-model/src/main/java/org/hawkular/inventory/model/Resource.java
+++ b/hawkular-inventory-parent/hawkular-inventory-model/src/main/java/org/hawkular/inventory/model/Resource.java
@@ -24,11 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.hibernate.search.annotations.Analyze;
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.annotations.Store;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -37,7 +32,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * @author Joel Takvorian
  */
-@Indexed
 public class Resource implements Serializable {
 
     public static class Builder {
@@ -105,15 +99,12 @@ public class Resource implements Serializable {
     private final String name;
 
     @JsonInclude(Include.NON_NULL)
-    @Field(store = Store.YES, analyze = Analyze.NO, indexNullAs = Field.DEFAULT_NULL_TOKEN)
     private final String feedId;
 
     @JsonInclude(Include.NON_NULL)
-    @Field(store = Store.YES, analyze = Analyze.NO, indexNullAs = Field.DEFAULT_NULL_TOKEN)
     private final String typeId;
 
     @JsonInclude(Include.NON_NULL)
-    @Field(store = Store.YES, analyze = Analyze.NO, indexNullAs = Field.DEFAULT_NULL_TOKEN)
     private final String parentId;
 
     @JsonInclude(Include.NON_NULL)

--- a/hawkular-inventory-parent/hawkular-inventory-model/src/main/java/org/hawkular/inventory/model/ResourceType.java
+++ b/hawkular-inventory-parent/hawkular-inventory-model/src/main/java/org/hawkular/inventory/model/ResourceType.java
@@ -24,11 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.hibernate.search.annotations.Analyze;
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.annotations.Store;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -36,7 +31,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * @author Joel Takvorian
  */
-@Indexed
 public class ResourceType implements Serializable {
 
     public static class Builder {
@@ -74,7 +68,6 @@ public class ResourceType implements Serializable {
     }
 
     @JsonInclude(Include.NON_NULL)
-    @Field(store = Store.YES, analyze = Analyze.NO, indexNullAs = Field.DEFAULT_NULL_TOKEN)
     private final String id;  // Unique index [Search resource type by id]
 
     @JsonInclude(Include.NON_NULL)

--- a/hawkular-inventory-parent/hawkular-inventory-service/pom.xml
+++ b/hawkular-inventory-parent/hawkular-inventory-service/pom.xml
@@ -311,7 +311,10 @@
   </build>
 
   <properties>
-    <excluded.groups>org.hawkular.inventory.service.Performance</excluded.groups>
+    <!--
+      [lponce] making perf tests optional is prone to errors
+      <excluded.groups>org.hawkular.inventory.service.Performance</excluded.groups>
+    -->
   </properties>
 
 </project>

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/ispn/IspnResource.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/ispn/IspnResource.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.service.ispn;
+
+import java.io.Serializable;
+
+import org.hawkular.inventory.model.Metric;
+import org.hawkular.inventory.model.Resource;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Store;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Indexed(index = "resource")
+public class IspnResource implements Serializable {
+
+    @Field(store = Store.YES, analyze = Analyze.NO, indexNullAs = Field.DEFAULT_NULL_TOKEN)
+    private final String feedId;
+
+    @Field(store = Store.YES, analyze = Analyze.NO, indexNullAs = Field.DEFAULT_NULL_TOKEN)
+    private final String typeId;
+
+    @Field(store = Store.YES, analyze = Analyze.NO, indexNullAs = Field.DEFAULT_NULL_TOKEN)
+    private final String parentId;
+
+    private final Resource resource;
+
+    public IspnResource(Resource resource) {
+        if (resource == null) {
+            throw new IllegalStateException("Resource must be not null");
+        }
+        this.feedId = resource.getFeedId();
+        this.typeId = resource.getTypeId();
+        this.parentId = resource.getParentId();
+        this.resource = cloneResource(resource);
+    }
+
+    public String getFeedId() {
+        return feedId;
+    }
+
+    public String getTypeId() {
+        return typeId;
+    }
+
+    public String getParentId() {
+        return parentId;
+    }
+
+    public Resource getResource() {
+        if (resource == null) {
+            return null;
+        }
+        return cloneResource(resource);
+    }
+
+    private Resource cloneResource(Resource resource) {
+        if (resource == null) {
+            return null;
+        }
+        Resource.Builder builder = Resource.builder()
+                .id(resource.getId())
+                .name(resource.getName())
+                .feedId(resource.getFeedId())
+                .typeId(resource.getTypeId())
+                .parentId(resource.getParentId());
+        if (resource.getMetrics() != null) {
+            for (Metric metric : resource.getMetrics()) {
+                // TODO [lponce] clone metric ?
+                builder.metric(metric);
+            }
+        }
+        if (resource.getProperties() != null) {
+            // TODO [lponce] clone properties ?
+            builder.properties(resource.getProperties());
+        }
+        return builder.build();
+    }
+}

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/ispn/IspnResourceType.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/ispn/IspnResourceType.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.service.ispn;
+
+import java.io.Serializable;
+
+import org.hawkular.inventory.model.Operation;
+import org.hawkular.inventory.model.ResourceType;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Store;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Indexed(index = "resourceType")
+public class IspnResourceType implements Serializable {
+
+    @Field(store = Store.YES, analyze = Analyze.NO, indexNullAs = Field.DEFAULT_NULL_TOKEN)
+    private final String id;  // Unique index [Search resource type by id]
+
+    private final ResourceType resourceType;
+
+    public IspnResourceType(ResourceType resourceType) {
+        if (resourceType == null) {
+            throw new IllegalStateException("ResourceType must be not null");
+        }
+        this.id = resourceType.getId();
+        this.resourceType = cloneResourceType(resourceType);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public ResourceType getResourceType() {
+        if (resourceType == null) {
+            return null;
+        }
+        return cloneResourceType(resourceType);
+    }
+
+    private ResourceType cloneResourceType(ResourceType resourceType) {
+        if (resourceType == null) {
+            return null;
+        }
+        ResourceType.Builder builder = ResourceType.builder()
+                .id(resourceType.getId())
+                .properties(resourceType.getProperties());
+        if (resourceType.getOperations() != null) {
+            for (Operation operation : resourceType.getOperations()) {
+                builder.operation(operation);
+            }
+        }
+        return builder.build();
+    }
+}

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/resources/hawkular-inventory-ispn.xml
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/resources/hawkular-inventory-ispn.xml
@@ -23,7 +23,7 @@
     xmlns="urn:infinispan:config:9.1">
 
   <cache-container name="hawkular-inventory">
-
+    <jmx duplicate-domains="true" />
     <local-cache name="resource">
       <transaction mode="NON_XA"/>
       <persistence>
@@ -42,7 +42,7 @@
       </memory>
       <indexing index="LOCAL">
         <indexed-entities>
-          <indexed-entity>org.hawkular.inventory.model.Resource</indexed-entity>
+          <indexed-entity>org.hawkular.inventory.service.ispn.IspnResource</indexed-entity>
         </indexed-entities>
         <property name="default.indexmanager">near-real-time</property>
         <property name="default.directory_provider">infinispan</property>
@@ -97,7 +97,7 @@
       </persistence>
       <indexing index="LOCAL">
         <indexed-entities>
-          <indexed-entity>org.hawkular.inventory.model.ResourceType</indexed-entity>
+          <indexed-entity>org.hawkular.inventory.service.ispn.IspnResourceType</indexed-entity>
         </indexed-entities>
         <property name="default.indexmanager">near-real-time</property>
         <property name="default.directory_provider">infinispan</property>

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/resources/hawkular-inventory-ispn-test.xml
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/resources/hawkular-inventory-ispn-test.xml
@@ -23,7 +23,7 @@
     xmlns="urn:infinispan:config:9.1">
 
   <cache-container name="hawkular-inventory">
-
+    <jmx duplicate-domains="true" />
     <local-cache name="resource">
       <transaction mode="NON_XA"/>
       <persistence>
@@ -42,7 +42,7 @@
       </memory>
       <indexing index="LOCAL">
         <indexed-entities>
-          <indexed-entity>org.hawkular.inventory.model.Resource</indexed-entity>
+          <indexed-entity>org.hawkular.inventory.service.ispn.IspnResource</indexed-entity>
         </indexed-entities>
         <property name="default.indexmanager">near-real-time</property>
         <property name="default.directory_provider">infinispan</property>
@@ -97,7 +97,7 @@
       </persistence>
       <indexing index="LOCAL">
         <indexed-entities>
-          <indexed-entity>org.hawkular.inventory.model.ResourceType</indexed-entity>
+          <indexed-entity>org.hawkular.inventory.service.ispn.IspnResourceType</indexed-entity>
         </indexed-entities>
         <property name="default.indexmanager">near-real-time</property>
         <property name="default.directory_provider">infinispan</property>


### PR DESCRIPTION
@jotak, this is related our discussion on friday.
This approach was followed in Alerting 2.x, basically the idea is to separate the object used to store in the backend vs the object used in the Java API, and make it inmutable.
Also, this PR fixes performance tests and makes them mandatory in the profile.