### PR TITLE
Bring back UpdateCollectionIntervals commands

### DIFF
--- a/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/UpdateCollectionIntervalsRequest.schema.json
+++ b/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/UpdateCollectionIntervalsRequest.schema.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "extends": {
+    "type": "object",
+    "javaType": "org.hawkular.cmdgw.api.ResourceRequest"
+  },
+  "javaType": "org.hawkular.cmdgw.api.UpdateCollectionIntervalsRequest",
+  "javaInterfaces" : ["org.hawkular.cmdgw.api.ResourceDestination"],
+  "additionalProperties": false,
+  "description": "A request to update one or more collection intervals. ResourceId should be a resource managed by the target agent.",
+  "properties": {
+    "metricTypes": {
+      "description": "A map with key=metricTypeId, value=interval (seconds). metricType is inventory metric type id",
+      "type": "object",
+      "javaType": "java.util.Map<String, String>"
+    },
+    "availTypes": {
+      "description": "A map with key=availType, value=interval (seconds). metricType is inventory metric type id",
+      "type": "object",
+      "javaType": "java.util.Map<String, String>"
+    }
+  },
+  "required": ["metricTypes","availTypes"]
+}
+

--- a/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/UpdateCollectionIntervalsResponse.schema.json
+++ b/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/UpdateCollectionIntervalsResponse.schema.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "extends": {
+    "type": "object",
+    "javaType": "org.hawkular.cmdgw.api.ResourceResponse"
+  },
+  "javaType": "org.hawkular.cmdgw.api.UpdateCollectionIntervalsResponse",
+  "javaInterfaces" : ["org.hawkular.cmdgw.api.EventDestination"],
+  "description": "Result of the collection intervals update.",
+  "additionalProperties": false
+}

--- a/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/UpdateDatasourceRequest.schema.json
+++ b/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/UpdateDatasourceRequest.schema.json
@@ -5,6 +5,6 @@
     "javaType": "org.hawkular.cmdgw.api.AddDatasourceRequest"
   },
   "javaType": "org.hawkular.cmdgw.api.UpdateDatasourceRequest",
-  "description": "Updates the Datasource or a XA Datasource given by the inventory path stored in resourcePath field.",
+  "description": "Updates the Datasource or a XA Datasource given by the inventory path stored in resourceId field.",
   "additionalProperties": false
 }


### PR DESCRIPTION
In the context of Prometheus, we dropped collection interval commands.
Restoring these classes to enable CmdGw sync correctly with the agent.