### PR TITLE
DISABLING THESE TWO TESTS.

### DIFF
--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/handlers/InventoryPerfTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/handlers/InventoryPerfTest.java
@@ -16,7 +16,6 @@
  */
 package org.hawkular.inventory.handlers;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -44,7 +43,6 @@ import org.hawkular.inventory.api.model.MetricUnit;
 import org.hawkular.inventory.api.model.Operation;
 import org.hawkular.inventory.api.model.RawResource;
 import org.hawkular.inventory.api.model.ResourceType;
-import org.hawkular.inventory.api.model.ResultSet;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -217,6 +215,11 @@ public class InventoryPerfTest {
         assertEquals(200, response.getStatus());
     }
 
+// TODO: fix these tests - taking over 10 minutes before I had to kill it - it probably would have taken much longer to finish:
+// 16:12:19,047 INFO  [org.infinispan.query.impl.massindex.DefaultMassIndexerProgressMonitor] (DefaultExecutorService--p24-t1) ISPN014015: 50 documents indexed in 19 ms
+// 16:19:32,743 INFO  [org.infinispan.query.impl.massindex.DefaultMassIndexerProgressMonitor] (DefaultExecutorService--p24-t1) ISPN014015: 488350 documents indexed in 433103 ms
+// 16:22:31,377 INFO  [org.infinispan.query.impl.massindex.DefaultMassIndexerProgressMonitor] (DefaultExecutorService--p24-t1) ISPN014015: 488400 documents indexed in 611720 ms
+/*
     @Test
     public void test002_largeImportWithStats() {
         Client client = ClientBuilder.newClient();
@@ -304,4 +307,5 @@ public class InventoryPerfTest {
                 .extracting(ResourceType::getId)
                 .containsOnly("EAP", "FOO", "BAR", "JDG");
     }
+*/
 }


### PR DESCRIPTION
 They are taking a long time to complete (I had to kill the tests before completing after my machine was smoking after 10 minutes).

We need to fix these tests - either reduce the size of inventory, have them only run when a particular mvn profile is activated, or something like that.