### PR TITLE
Add avail metrics for deployments.

### DIFF
--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/resources/wildfly-10-jmx-exporter.yml
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/resources/wildfly-10-jmx-exporter.yml
@@ -47,6 +47,22 @@ rules:
     labels:
       name: $1
 
+  - pattern: "^jboss.as<deployment=(.+)><>status: OK"
+    attrNameSnakeCase: true
+    name: wildfly_deployment_availability
+    value: 1
+    type: GAUGE
+    labels:
+      name: $1
+
+  - pattern: "^jboss.as<deployment=(.+)><>status: (FAILED|STOPPED)"
+    attrNameSnakeCase: true
+    name: wildfly_deployment_availability
+    value: 0
+    type: GAUGE
+    labels:
+      name: $1
+
   # MESSAGING
 
   - pattern: "^jboss.as<subsystem=messaging-activemq, server=(.+), jms-(queue|topic)=(.+)><>(.+):"


### PR DESCRIPTION
Since Prometheus doesn't support string or avail metrics, if a deployment status is OK, the metric has a value of "1" and if it's stopped or failed to deploy its metric value is "0". Such as:

```
# HELP wildfly_deployment_availability The current runtime status of a deployment. Possible status modes are OK, FAILED, and STOPPED. FAILED indicates a dependency is missing or a service could not start. STOPPED indicates that the deployment was not enabled or was manually stopped. (jboss.as<deployment=kitchensink-ear.ear><>status)
# TYPE wildfly_deployment_availability gauge
wildfly_deployment_availability{name="kitchensink-ear.ear",} 1.0
wildfly_deployment_availability{name="test-little-1.0.0.ear",} 1.0
wildfly_deployment_availability{name="test-simple-1.0.0.war",} 0.0
```