### PR TITLE
Can now build -P-ui to optionally omit the ui build. 

### DIFF
--- a/hawkular-inventory-parent/hawkular-inventory-ui/pom.xml
+++ b/hawkular-inventory-parent/hawkular-inventory-ui/pom.xml
@@ -47,30 +47,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <configuration>
-          <excludes>**/.sass-cach/**,**/bower_components/**,**/dist/**,**/node_modules/**</excludes>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>com.mycila</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-        <configuration>
-          <excludes combine.children="append">
-            <exclude>**/*.htmlhintrc</exclude>
-            <exclude>**/*.scss</exclude>
-            <exclude>**/ui/.sass-cache/**</exclude>
-            <exclude>**/ui/bower_components/**</exclude>
-            <exclude>**/ui/dist/**</exclude>
-            <exclude>**/ui/node_modules/**</exclude>
-            <exclude>**/ui/src/templates/**</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <version>${version.org.apache.maven.plugins.maven-resources-plugin}</version>
         <executions>

--- a/hawkular-inventory-parent/pom.xml
+++ b/hawkular-inventory-parent/pom.xml
@@ -31,11 +31,50 @@
 
   <name>Hawkular Inventory: Parent</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <excludes>**/.sass-cach/**,**/bower_components/**,**/dist/**,**/node_modules/**</excludes>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <excludes combine.children="append">
+            <exclude>**/*.htmlhintrc</exclude>
+            <exclude>**/*.scss</exclude>
+            <exclude>**/ui/.sass-cache/**</exclude>
+            <exclude>**/ui/bower_components/**</exclude>
+            <exclude>**/ui/dist/**</exclude>
+            <exclude>**/ui/node_modules/**</exclude>
+            <exclude>**/ui/src/templates/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <modules>
     <module>hawkular-inventory-api</module>
     <module>hawkular-inventory-service</module>
-    <module>hawkular-inventory-ui</module>
     <module>hawkular-inventory-itest</module>
   </modules>
+
+  <profiles>
+    <profile>
+      <id>ui</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>hawkular-inventory-ui</module>
+      </modules>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
This is primarily to speed up dev builds and as such the ui is still built by default.