### PR TITLE
allows agents to register metrics endpoints

### DIFF
--- a/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/InventoryService.java
+++ b/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/InventoryService.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Optional;
 
 import org.hawkular.inventory.api.model.InventoryHealth;
+import org.hawkular.inventory.api.model.MetricsEndpoint;
 import org.hawkular.inventory.api.model.RawResource;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.api.model.ResourceNode;
@@ -146,6 +147,13 @@ public interface InventoryService {
      * @return config file content as String, if found
      */
     Optional<String> getJMXExporterConfig(String templateName);
+
+    /**
+     * Registers a metrics endpoint that can be scraped for metric data.
+     *
+     * @return true if the registration succeeded, false otherwise.
+     */
+    boolean registerMetricsEndpoint(MetricsEndpoint metricsEndpoint);
 
     /**
      * @return true is InventoryService is Up and Running

--- a/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/MetricsEndpoint.java
+++ b/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/MetricsEndpoint.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.model;
+
+import java.io.Serializable;
+
+import org.hawkular.commons.doc.DocModel;
+import org.hawkular.commons.doc.DocModelProperty;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * This represents an agent's metrics endpoint that can be scraped for metrics data.
+ *
+ * @author John Mazzitelli
+ */
+@DocModel(description = "Representation of an endpoint that can be scraped for metrics data.")
+public class MetricsEndpoint implements Serializable {
+
+    public static class Builder {
+        private String feedId;
+        private String host;
+        private Integer port;
+
+        public MetricsEndpoint build() {
+            return new MetricsEndpoint(feedId, host, port);
+        }
+
+        public Builder feedId(String feedId) {
+            this.feedId = feedId;
+            return this;
+        }
+
+        public Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public Builder port(Integer port) {
+            this.port = port;
+            return this;
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @DocModelProperty(description = "The feed ID of the metrics endpoint agent.",
+            position = 0,
+            required = true)
+    @JsonInclude(Include.NON_NULL)
+    private final String feedId;
+
+    @DocModelProperty(description = "Host where the metrics endpoint is located.",
+            position = 1,
+            required = true)
+    @JsonInclude(Include.NON_NULL)
+    private final String host;
+
+    @DocModelProperty(description = "Port on the host where the endpoint is listening.",
+            position = 2,
+            required = true)
+    @JsonInclude(Include.NON_NULL)
+    private final Integer port;
+
+    public MetricsEndpoint(@JsonProperty("feedId") String feedId,
+            @JsonProperty("host") String host,
+            @JsonProperty("port") Integer port) {
+        this.feedId = feedId;
+        this.host = host;
+        this.port = port;
+    }
+
+    public String getFeedId() {
+        return feedId;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    @Override
+    public String toString() {
+        return "MetricsEndpoint{" +
+                "feedId='" + feedId + '\'' +
+                ", host='" + host + '\'' +
+                ", port=" + port +
+                '}';
+    }
+}

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/handlers/InventoryHandlers.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/handlers/InventoryHandlers.java
@@ -52,6 +52,7 @@ import org.hawkular.inventory.api.InventoryService;
 import org.hawkular.inventory.api.ResourceFilter;
 import org.hawkular.inventory.api.model.Inventory;
 import org.hawkular.inventory.api.model.InventoryHealth;
+import org.hawkular.inventory.api.model.MetricsEndpoint;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.api.model.ResourceNode;
 import org.hawkular.inventory.api.model.ResourceType;
@@ -236,6 +237,38 @@ public class InventoryHandlers {
                 inventoryService.addResourceType(inventory.getTypes());
             }
             return ResponseUtil.ok();
+        } catch (Exception e) {
+            return ResponseUtil.internalError(e);
+        }
+    }
+
+    @DocPath(method = "POST", path = "/register-metrics-endpoint", name = "Registers a feed metrics endpoint so it can be scraped for metric data.", notes = "This will write a configuration file for Prometheus so it can begin collecting metrics.")
+    @DocParameters(value = {
+            @DocParameter(required = true, body = true, type = MetricsEndpoint.class, description = "Describes the metrics endpoint t be registered.")
+    })
+    @DocResponses(value = {
+            @DocResponse(code = 200, message = "Success, metrics endpoint has been registered."),
+            @DocResponse(code = 500, message = "Internal server error.", response = ApiError.class)
+    })
+    @POST
+    @Path("/register-metrics-endpoint")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    public Response registerMetricsEndpoint(final MetricsEndpoint metricsEndpoint) {
+        try {
+            boolean ok;
+            if (metricsEndpoint != null) {
+                ok = inventoryService.registerMetricsEndpoint(metricsEndpoint);
+            } else {
+                log.errorNullValue("metricsEndpoint");
+                ok = false;
+            }
+
+            if (ok) {
+                return ResponseUtil.ok();
+            } else {
+                return ResponseUtil.internalError("Cannot register metrics endpoint. Server-side logs has details.");
+            }
         } catch (Exception e) {
             return ResponseUtil.internalError(e);
         }

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/log/MsgLogger.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/log/MsgLogger.java
@@ -69,4 +69,15 @@ public interface MsgLogger {
     @Message(id = 100009, value = "Changing polling stats interval to [%s] ms")
     void infoChangingPollingStatsInterval(long newPollingInterval);
 
+    @LogMessage(level = Level.INFO)
+    @Message(id = 100010, value = "Registered feed [%s] metrics endpoint [%s:%d]: %s")
+    void infoRegisteredMetricsEndpoint(String feedId, String host, Integer port, String fileName);
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 100011, value = "Cannot register feed [%s] metrics endpoint [%s:%d]")
+    void errorCannotRegisterMetricsEndpoint(String feedId, String host, Integer port, @Cause Throwable throwable);
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 100012, value = "The value of [%s] is null")
+    void errorNullValue(String variableName);
 }


### PR DESCRIPTION
This adds an inventory REST handler that the agent will call upon startup. This handler "register-metrics-endpoint" will create a Prometheus config file that will tell Prometheus where to scrape the agent's jmx exporter endpoint and that all metrics should have a feed-id label associated with them.

We will need configure our Prometheus server to scan our h-services standalone/configuration/hawkular/prometheus directory for these json files. See: https://prometheus.io/docs/operating/configuration/#<file_sd_config>