### PR TITLE
HAWKULAR-1292 Have Inventory update the Prometheus scrape endpoints

### DIFF
--- a/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/InventoryService.java
+++ b/hawkular-inventory-parent/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/InventoryService.java
@@ -155,4 +155,6 @@ public interface InventoryService {
     void buildExport(OutputStream os) throws IOException;
 
     InventoryHealth getHealthStatus();
+
+    void buildMetricsEndpoints();
 }

--- a/hawkular-inventory-parent/hawkular-inventory-itest/pom.xml
+++ b/hawkular-inventory-parent/hawkular-inventory-itest/pom.xml
@@ -201,6 +201,7 @@
                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                 <logging.configuration>file:${project.build.directory}/test-classes/logging.properties</logging.configuration>
                 <jboss.home>${project.basedir}/target/wildfly-${version.org.wildfly}/</jboss.home>
+                <test.prometheus.config>${project.basedir}/target/wildfly-${version.org.wildfly}/standalone/configuration/hawkular/prometheus</test.prometheus.config>
               </systemPropertyVariables>
               <redirectTestOutputToFile>false</redirectTestOutputToFile>
             </configuration>
@@ -341,6 +342,7 @@
                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                 <logging.configuration>file:${project.build.directory}/test-classes/logging.properties</logging.configuration>
                 <jboss.home>${eap.home}</jboss.home>
+                <test.prometheus.config>${eap.home}/standalone/configuration/hawkular/prometheus</test.prometheus.config>
               </systemPropertyVariables>
               <redirectTestOutputToFile>false</redirectTestOutputToFile>
             </configuration>

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/log/MsgLogger.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/log/MsgLogger.java
@@ -80,4 +80,8 @@ public interface MsgLogger {
     @LogMessage(level = Level.ERROR)
     @Message(id = 100012, value = "Cannot register feed [%s] metrics endpoint [%s]")
     void errorCannotRegisterMetricsEndpoint(String feedId, String metricsEndpoint, @Cause Throwable throwable);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 100013, value = "Rebuild registered metrics endpoints")
+    void infoRebuildRegisteredMetricsEndpoints();
 }

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/log/MsgLogger.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/log/MsgLogger.java
@@ -69,4 +69,15 @@ public interface MsgLogger {
     @Message(id = 100009, value = "Changing polling stats interval to [%s] ms")
     void infoChangingPollingStatsInterval(long newPollingInterval);
 
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 100010, value = "Agent [%s] has not feedId or Metrics endpoint data")
+    void errorMissingInfoInAgentRegistration(String resourceId);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 100011, value = "Registered feed [%s] metrics endpoint [%s]: %s")
+    void infoRegisteredMetricsEndpoint(String feedId, String metricsEndpoint, String fileName);
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 100012, value = "Cannot register feed [%s] metrics endpoint [%s]")
+    void errorCannotRegisterMetricsEndpoint(String feedId, String metricsEndpoint, @Cause Throwable throwable);
 }

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryConfigPath.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryConfigPath.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.service;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, FIELD, PARAMETER})
+public @interface InventoryConfigPath {
+}

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/ScrapeConfig.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/ScrapeConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.service;
+
+import java.util.Map;
+
+import org.hawkular.inventory.api.model.RawResource;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class ScrapeConfig {
+
+    @JsonInclude(Include.NON_NULL)
+    private Map<String, String> filter;
+
+    public ScrapeConfig(@JsonProperty("filter") Map<String, String> filter) {
+        this.filter = filter;
+    }
+
+    public Map<String, String> getFilter() {
+        return filter;
+    }
+
+    public boolean filter(RawResource resource) {
+        if (resource == null || resource.getTypeId() == null) {
+            return false;
+        }
+        return filter.containsKey(resource.getTypeId());
+    }
+
+    @Override
+    public String toString() {
+        return "ScrapeConfig{" +
+                "filter=" + filter +
+                '}';
+    }
+}

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/ScrapeConfigInit.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/ScrapeConfigInit.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.service;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.EJB;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+
+import org.hawkular.inventory.api.InventoryService;
+import org.hawkular.inventory.log.InventoryLoggers;
+import org.hawkular.inventory.log.MsgLogger;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Startup
+@Singleton
+public class ScrapeConfigInit {
+    private static final MsgLogger log = InventoryLoggers.getLogger(ScrapeConfigInit.class);
+
+    @EJB
+    private InventoryService service;
+
+    @PostConstruct
+    public void init() {
+        log.infoRebuildRegisteredMetricsEndpoints();
+        service.buildMetricsEndpoints();
+    }
+
+}

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/ScrapeLocation.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/ScrapeLocation.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.service;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, FIELD, PARAMETER})
+public @interface ScrapeLocation {
+}

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/resources/hawkular-inventory-prometheus-scrape-config.yaml
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/resources/hawkular-inventory-prometheus-scrape-config.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+filter:
+  # <RawResource type to filter>: <RawResource.config key where Metrics Endpoint in format <host:port> can be found
+  Hawkular WildFly Agent: Metrics Endpoint

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryServiceIspnTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryServiceIspnTest.java
@@ -412,6 +412,11 @@ public class InventoryServiceIspnTest {
                 .config("Metrics Endpoint", "localhost:1234")
                 .build();
         service.addResource(agent);
-        Assert.assertTrue(new File(PROMETHEUS_SCRAPE_CONFIG, "my-test-feed.json").exists());
+        File testFile = new File(PROMETHEUS_SCRAPE_CONFIG, "my-test-feed.json");
+        Assert.assertTrue(testFile.exists());
+        testFile.delete();
+        Assert.assertFalse(testFile.exists());
+        service.buildMetricsEndpoints();
+        Assert.assertTrue(testFile.exists());
     }
 }

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryServiceIspnTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryServiceIspnTest.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
+import org.hawkular.commons.json.JsonUtil;
 import org.hawkular.inventory.Resources;
 import org.hawkular.inventory.api.ResourceFilter;
 import org.hawkular.inventory.api.model.Inventory;
@@ -43,6 +44,7 @@ import org.infinispan.Cache;
 import org.infinispan.configuration.cache.SingleFileStoreConfiguration;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -56,6 +58,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class InventoryServiceIspnTest {
 
     private static final String ISPN_CONFIG_LOCAL = "/hawkular-inventory-ispn-test.xml";
+    private static final String SCRAPE_CONFIG_LOCAL = "/hawkular-inventory-prometheus-scrape-config.yaml";
+    private static final String PROMETHEUS_SCRAPE_CONFIG = "target/prometheus";
     private static EmbeddedCacheManager CACHE_MANAGER;
     private final InventoryServiceIspn service;
     private final InventoryStats inventoryStats;
@@ -87,7 +91,15 @@ public class InventoryServiceIspnTest {
                         .iterator()
                         .next()).location()));
         inventoryStats.init();
-        service = new InventoryServiceIspn(resource, resourceType, getClass().getClassLoader().getResource("").getPath(), inventoryStats);
+        ScrapeConfig scrapeConfig = null;
+        try {
+            scrapeConfig = JsonUtil.getYamlMapper().readValue(InventoryServiceIspn.class.getResourceAsStream(SCRAPE_CONFIG_LOCAL), ScrapeConfig.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        File scrapeLocation = new File(PROMETHEUS_SCRAPE_CONFIG);
+        scrapeLocation.mkdirs();
+        service = new InventoryServiceIspn(resource, resourceType, getClass().getClassLoader().getResource("").getPath(), inventoryStats, scrapeConfig, scrapeLocation);
     }
 
     @Before
@@ -389,5 +401,17 @@ public class InventoryServiceIspnTest {
                     .extracting(Resource::getId)
                     .doesNotContain(idXaDsX);
         }
+    }
+
+    @Test
+    public void shouldGenerateScrapeConfig() {
+        RawResource agent = RawResource.builder()
+                .id("my-test-agent")
+                .feedId("my-test-feed")
+                .typeId("Hawkular WildFly Agent")
+                .config("Metrics Endpoint", "localhost:1234")
+                .build();
+        service.addResource(agent);
+        Assert.assertTrue(new File(PROMETHEUS_SCRAPE_CONFIG, "my-test-feed.json").exists());
     }
 }

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/ScrapeConfigTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/ScrapeConfigTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.hawkular.commons.json.JsonUtil;
+import org.junit.Test;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class ScrapeConfigTest {
+    @Test
+    public void testReadConfigYaml() throws Exception {
+        ScrapeConfig config = JsonUtil.getYamlMapper().readValue(ScrapeConfigTest.class.getResourceAsStream("/hawkular-inventory-prometheus-scrape-config.yaml"), ScrapeConfig.class);
+        assertEquals(1, config.getFilter().size());
+        assertTrue(config.getFilter().containsKey("Hawkular WildFly Agent"));
+        assertEquals("Metrics Endpoint", config.getFilter().get("Hawkular WildFly Agent"));
+    }
+}

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/resources/hawkular-inventory-prometheus-scrape-config.yaml
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/resources/hawkular-inventory-prometheus-scrape-config.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+filter:
+  # <RawResource type to filter>: <RawResource.config key where Metrics Endpoint in format <host:port> can be found
+  Hawkular WildFly Agent: Metrics Endpoint

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -63,5 +63,10 @@
       <artifactId>jackson-databind</artifactId>
       <version>${version.com.fasterxml.jackson.core}</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <version>${version.com.fasterxml.jackson.core}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/utils/src/main/java/org/hawkular/commons/json/JsonUtil.java
+++ b/utils/src/main/java/org/hawkular/commons/json/JsonUtil.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 /**
  * Json serialization/deserialization utility using Jackson implementation.
@@ -36,6 +37,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public final class JsonUtil {
 
     private static ObjectMapper MAPPER = new ObjectMapper();
+    private static ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
 
     private JsonUtil() {
     }
@@ -77,5 +79,9 @@ public final class JsonUtil {
         JsonGenerator jsonGen = new JsonFactory().createGenerator(os, JsonEncoding.UTF8);
         jsonGen.setCodec(MAPPER);
         return jsonGen;
+    }
+
+    public static ObjectMapper getYamlMapper() {
+        return YAML_MAPPER;
     }
 }


### PR DESCRIPTION
As discussed in HAWKULAR-1292 this PRs filters inventory and when an agent is added, it will create the Prometheus configuration file.
Then, the agent has not to invoke this operation, this happens on registration (or modification) of agents in inventory.
This filter is cheap in terms of performance, so I don't see a problem here.
Also, filters are defined from configuration.
Today there is the assumption that there is a single p8s server, and probably very soon we will play with other topologies, then this scheme can be used to maintain the state which agent is managed  in which p8s server.