### PR TITLE
fix metrics endpoint filter

### DIFF
--- a/hawkular-inventory-parent/hawkular-inventory-itest/src/test/java/org/hawkular/inventory/handlers/InventoryRestTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-itest/src/test/java/org/hawkular/inventory/handlers/InventoryRestTest.java
@@ -638,7 +638,7 @@ public class InventoryRestTest extends AbstractInventoryITest {
     public void test105_shouldCreateAPrometheusJsonConfig() {
         String id = "my-test-agent";
         String feedId = "my-test-feed";
-        String type = "Hawkular WildFly Agent";
+        String type = "Hawkular Java Agent";
         int numIterations = 1000;
         String testPrometheusConfig = System.getProperty("test.prometheus.config");
 

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/log/MsgLogger.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/log/MsgLogger.java
@@ -84,4 +84,8 @@ public interface MsgLogger {
     @LogMessage(level = Level.INFO)
     @Message(id = 100013, value = "Rebuild registered metrics endpoints")
     void infoRebuildRegisteredMetricsEndpoints();
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 100014, value = "Using scrape config file [%s]")
+    void infoUsingScrapeConfigFile(String file);
 }

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryConfig.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryConfig.java
@@ -127,8 +127,10 @@ public class InventoryConfig {
             File scrapeConfigFile = new File(configPath.toFile(), SCRAPE_CONFIGURATION);
             if (scrapeConfigFile.exists()) {
                 scrapeConfig = JsonUtil.getYamlMapper().readValue(scrapeConfigFile, ScrapeConfig.class);
+                log.infoUsingScrapeConfigFile(scrapeConfigFile.getAbsolutePath());
             } else {
                 scrapeConfig = JsonUtil.getYamlMapper().readValue(InventoryConfig.class.getResourceAsStream("/" + SCRAPE_CONFIGURATION), ScrapeConfig.class);
+                log.infoUsingScrapeConfigFile("internal default");
             }
             scrapeLocation = new File(configPath.toFile(), "prometheus");
             scrapeLocation.mkdirs();

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryServiceIspn.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryServiceIspn.java
@@ -273,8 +273,10 @@ public class InventoryServiceIspn implements InventoryService {
     }
 
     private Optional<String> getConfig(String fileName) {
-        // TODO: maybe some defensive check against file traversal attack?
-        //  Or check that "resourceType" is in a whitelist of types?
+        if (fileName.contains("..")) {
+            throw new IllegalArgumentException("Cannot get file with '..' in path: " + fileName);
+        }
+
         try {
             byte[] encoded = Files.readAllBytes(configPath.resolve(fileName));
             return Optional.of(new String(encoded, StandardCharsets.UTF_8.name()));
@@ -417,6 +419,10 @@ public class InventoryServiceIspn implements InventoryService {
         if (isEmpty(feedId) || isEmpty(metricsEndpoint)) {
             log.errorMissingInfoInAgentRegistration(rawResource.getId());
             return;
+        }
+
+        if (feedId.contains("..")) {
+            throw new IllegalArgumentException("Cannot write metrics endpoint file with '..' in path: " + feedId);
         }
 
         // Prometheus file format. See: https://prometheus.io/docs/operating/configuration/#<file_sd_config>

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryServiceIspn.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryServiceIspn.java
@@ -426,7 +426,7 @@ public class InventoryServiceIspn implements InventoryService {
         }
 
         // Prometheus file format. See: https://prometheus.io/docs/operating/configuration/#<file_sd_config>
-        String content = String.format("[ { \"targets\": [ \"%s\" ], \"labels\": { \"feed-id\": \"%s\" } } ]",
+        String content = String.format("[ { \"targets\": [ \"%s\" ], \"labels\": { \"feed_id\": \"%s\" } } ]",
                 metricsEndpoint,
                 feedId);
         try {

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/resources/hawkular-inventory-prometheus-scrape-config.yaml
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/resources/hawkular-inventory-prometheus-scrape-config.yaml
@@ -18,4 +18,4 @@
 ---
 filter:
   # <RawResource type to filter>: <RawResource.config key where Metrics Endpoint in format <host:port> can be found
-  Hawkular WildFly Agent: Metrics Endpoint
+  Hawkular Java Agent: Metrics Endpoint

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryServiceIspnTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/InventoryServiceIspnTest.java
@@ -408,7 +408,7 @@ public class InventoryServiceIspnTest {
         RawResource agent = RawResource.builder()
                 .id("my-test-agent")
                 .feedId("my-test-feed")
-                .typeId("Hawkular WildFly Agent")
+                .typeId("Hawkular Java Agent")
                 .config("Metrics Endpoint", "localhost:1234")
                 .build();
         service.addResource(agent);

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/ScrapeConfigTest.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/java/org/hawkular/inventory/service/ScrapeConfigTest.java
@@ -31,7 +31,7 @@ public class ScrapeConfigTest {
     public void testReadConfigYaml() throws Exception {
         ScrapeConfig config = JsonUtil.getYamlMapper().readValue(ScrapeConfigTest.class.getResourceAsStream("/hawkular-inventory-prometheus-scrape-config.yaml"), ScrapeConfig.class);
         assertEquals(1, config.getFilter().size());
-        assertTrue(config.getFilter().containsKey("Hawkular WildFly Agent"));
-        assertEquals("Metrics Endpoint", config.getFilter().get("Hawkular WildFly Agent"));
+        assertTrue(config.getFilter().containsKey("Hawkular Java Agent"));
+        assertEquals("Metrics Endpoint", config.getFilter().get("Hawkular Java Agent"));
     }
 }

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/test/resources/hawkular-inventory-prometheus-scrape-config.yaml
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/test/resources/hawkular-inventory-prometheus-scrape-config.yaml
@@ -18,4 +18,4 @@
 ---
 filter:
   # <RawResource type to filter>: <RawResource.config key where Metrics Endpoint in format <host:port> can be found
-  Hawkular WildFly Agent: Metrics Endpoint
+  Hawkular Java Agent: Metrics Endpoint


### PR DESCRIPTION
This is part of HAWKULAR-1292

The name of the agent type is "Hawkular Java Agent".

This also adds come info log msgs at startup to know where its getting the config file.
Also puts in some checks to ensure no one tries to access filenames with ".." in the paths.