### PR TITLE
HAWKULAR-1325 Increase wait time for initialization

### DIFF
--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryConfig.java
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/java/org/hawkular/inventory/service/InventoryConfig.java
@@ -21,8 +21,10 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
+import javax.ejb.AccessTimeout;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
 import javax.enterprise.inject.Produces;
@@ -185,6 +187,7 @@ public class InventoryConfig {
 
     @Produces
     @InventoryConfigPath
+    @AccessTimeout(value = 300, unit = TimeUnit.SECONDS)
     public Path getConfigPath() {
         return configPath;
     }


### PR DESCRIPTION
InventoryConfig performs some tasks at init phase that might need more time than standard 5s, so, increasing this timeout will help on slow environments like travis where we have seen this issue.