### PR TITLE
clean up yaml

### DIFF
--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/resources/EAP6-inventory.yml
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/resources/EAP6-inventory.yml
@@ -26,54 +26,54 @@ metric-set-dmr:
   metric-dmr:
   - name: Heap Used
     metric-units: bytes
-    metric-type:  gauge
-    path:         /core-service=platform-mbean/type=memory
-    attribute:    heap-memory-usage#used
+    metric-type: gauge
+    path: /core-service=platform-mbean/type=memory
+    attribute: heap-memory-usage#used
     metric-family: jvm_memory_bytes_used
     metric-labels:
       area: heap
   - name: Heap Committed
     metric-units: bytes
-    metric-type:  gauge
-    path:         /core-service=platform-mbean/type=memory
-    attribute:    heap-memory-usage#committed
+    metric-type: gauge
+    path: /core-service=platform-mbean/type=memory
+    attribute: heap-memory-usage#committed
     metric-family: jvm_memory_bytes_committed
     metric-labels:
       area: heap
   - name: Heap Max
     metric-units: bytes
-    metric-type:  gauge
-    path:         /core-service=platform-mbean/type=memory
-    attribute:    heap-memory-usage#max
+    metric-type: gauge
+    path: /core-service=platform-mbean/type=memory
+    attribute: heap-memory-usage#max
     metric-family: jvm_memory_bytes_max
     metric-labels:
       area: heap
   - name: NonHeap Used
     metric-units: bytes
-    path:         /core-service=platform-mbean/type=memory
-    attribute:    non-heap-memory-usage#used
+    path: /core-service=platform-mbean/type=memory
+    attribute: non-heap-memory-usage#used
     metric-family: jvm_memory_bytes_used
     metric-labels:
       area: nonheap
   - name: NonHeap Committed
     metric-units: bytes
-    path:         /core-service=platform-mbean/type=memory
-    attribute:    non-heap-memory-usage#committed
+    path: /core-service=platform-mbean/type=memory
+    attribute: non-heap-memory-usage#committed
     metric-family: jvm_memory_bytes_committed
     metric-labels:
       area: nonheap
   - name: NonHeap Max
     metric-units: bytes
-    path:         /core-service=platform-mbean/type=memory
-    attribute:    non-heap-memory-usage#max
+    path: /core-service=platform-mbean/type=memory
+    attribute: non-heap-memory-usage#max
     metric-family: jvm_memory_bytes_max
     metric-labels:
       area: nonheap
   - name: Accumulated GC Duration
     metric-units: seconds
-    metric-type:  counter
-    path:         "/core-service=platform-mbean/type=garbage-collector/name=*"
-    attribute:    collection-time
+    metric-type: counter
+    path: "/core-service=platform-mbean/type=garbage-collector/name=*"
+    attribute: collection-time
     metric-family: jvm_gc_collection_seconds_sum
     metric-expression: sum($metric)
     # no metric-labels because we want to aggregate across all of them
@@ -81,52 +81,52 @@ metric-set-dmr:
 - name: WildFly Threading Metrics
   metric-dmr:
   - name: Thread Count
-    metric-type:  gauge
-    path:         /core-service=platform-mbean/type=threading
-    attribute:    thread-count
+    metric-type: gauge
+    path: /core-service=platform-mbean/type=threading
+    attribute: thread-count
     metric-family: jvm_threads_current
 
 - name: WildFly Aggregated Web Metrics
   metric-dmr:
   - name: Aggregated Active Web Sessions
-    path:       "/deployment=*/subsystem=web"
-    attribute:  active-sessions
+    path: "/deployment=*/subsystem=web"
+    attribute: active-sessions
     metric-family: wildfly_deployment_active_sessions
     metric-expression: sum($metric)
   - name: Aggregated Max Active Web Sessions
-    path:       "/deployment=*/subsystem=web"
-    attribute:  max-active-sessions
+    path: "/deployment=*/subsystem=web"
+    attribute: max-active-sessions
     metric-family: wildfly_deployment_max_active_sessions
     metric-expression: sum($metric)
   - name: Aggregated Expired Web Sessions
-    path:       "/deployment=*/subsystem=web"
-    attribute:  expired-sessions
+    path: "/deployment=*/subsystem=web"
+    attribute: expired-sessions
     metric-family: wildfly_deployment_expired_sessions
     metric-expression: sum($metric)
   - name: Aggregated Rejected Web Sessions
-    path:       "/deployment=*/subsystem=web"
-    attribute:  rejected-sessions
+    path: "/deployment=*/subsystem=web"
+    attribute: rejected-sessions
     metric-family: wildfly_deployment_rejected_sessions
     metric-expression: sum($metric)
   - name: Aggregated Servlet Request Time
-    path:       "/deployment=*/subsystem=web/servlet=*"
-    attribute:  processingTime
+    path: "/deployment=*/subsystem=web/servlet=*"
+    attribute: processingTime
     metric-family: wildfly_servlet_total_processing_time
     metric-expression: sum($metric)
   - name: Aggregated Servlet Request Count
-    path:       "/deployment=*/subsystem=web/servlet=*"
-    attribute:  requestCount
+    path: "/deployment=*/subsystem=web/servlet=*"
+    attribute: requestCount
     metric-family: wildfly_servlet_request_count
 
 - name: Web Subsystem Metrics
   metric-dmr:
   - name: Request Count
     attribute: requestCount
-    metric-type:  counter
+    metric-type: counter
     metric-family: wildfly_web_request_count
   - name: Error Count
     attribute: errorCount
-    metric-type:  counter
+    metric-type: counter
     metric-family: wildfly_web_error_count
   - name: Bytes Sent
     attribute: bytesSent
@@ -144,68 +144,68 @@ metric-set-dmr:
 - name: Web Metrics
   metric-dmr:
   - name: Active Sessions
-    path:       "/subsystem=web"
-    attribute:  active-sessions
+    path: "/subsystem=we/subsystem=web
+    attribute: active-sessions
     metric-family: wildfly_deployment_active_sessions
   - name: Sessions Created
-    path:       "/subsystem=web"
-    attribute:  sessions-created
+    path: /subsystem=web
+    attribute: sessions-created
     metric-type: counter
     metric-family: wildfly_deployment_sessions_created
   - name: Expired Sessions
-    path:       "/subsystem=web"
-    attribute:  expired-sessions
+    path: /subsystem=web
+    attribute: expired-sessions
     metric-type: counter
     metric-family: wildfly_deployment_expired_sessions
   - name: Rejected Sessions
-    path:       "/subsystem=web"
-    attribute:  rejected-sessions
+    path: /subsystem=web
+    attribute: rejected-sessions
     metric-type: counter
     metric-family: wildfly_deployment_rejected_sessions
   - name: Max Active Sessions
-    path:       "/subsystem=web"
-    attribute:  max-active-sessions
+    path: /subsystem=web
+    attribute: max-active-sessions
     metric-family: wildfly_deployment_max_active_sessions
 
 - name: Servlet Metrics
   metric-dmr:
   - name: Max Request Time
-    attribute:    maxTime
+    attribute: maxTime
     metric-units: milliseconds
     metric-family: wildfly_servlet_max_time
   - name: Min Request Time
-    attribute:    min-time
+    attribute: min-time
     metric-units: milliseconds
     metric-family: wildfly_servlet_min_time
   - name: Total Request Time
-    attribute:    processingTime
+    attribute: processingTime
     metric-units: milliseconds
     metric-family: wildfly_servlet_total_request_time
   - name: Request Count
-    attribute:    requestCount
-    metric-type:  counter
+    attribute: requestCount
+    metric-type: counter
     metric-family: wildfly_servlet_request_count
 
 - name: Singleton EJB Metrics
   metric-dmr:
   - name: Execution Time
-    attribute:    execution-time
+    attribute: execution-time
     metric-family: wildfly_ejb_execution_time
     metric-labels:
       type: singleton
   - name: Invocations
-    attribute:    invocations
-    metric-type:  counter
+    attribute: invocations
+    metric-type: counter
     metric-family: wildfly_ejb_invocations
     metric-labels:
       type: singleton
   - name: Peak Concurrent Invocations
-    attribute:    peak-concurrent-invocations
+    attribute: peak-concurrent-invocations
     metric-family: wildfly_ejb_peak_concurrent_invocations
     metric-labels:
       type: singleton
   - name: Wait Time
-    attribute:    wait-time
+    attribute: wait-time
     metric-family: wildfly_ejb_wait_time
     metric-labels:
       type: singleton
@@ -213,48 +213,48 @@ metric-set-dmr:
 - name: Message Driven EJB Metrics
   metric-dmr:
   - name: Execution Time
-    attribute:    execution-time
+    attribute: execution-time
     metric-family: wildfly_ejb_execution_time
     metric-labels:
       type: message-driven
   - name: Invocations
-    attribute:    invocations
-    metric-type:  counter
+    attribute: invocations
+    metric-type: counter
     metric-family: wildfly_ejb_invocations
     metric-labels:
       type: message-driven
   - name: Peak Concurrent Invocations
-    attribute:    peak-concurrent-invocations
+    attribute: peak-concurrent-invocations
     metric-family: wildfly_ejb_peak_concurrent_invocations
     metric-labels:
       type: message-driven
   - name: Wait Time
-    attribute:    wait-time
+    attribute: wait-time
     metric-family: wildfly_ejb_wait_time
     metric-labels:
       type: message-driven
   - name: Pool Available Count
-    attribute:    pool-available-count
+    attribute: pool-available-count
     metric-family: wildfly_ejb_pool_available_count
     metric-labels:
       type: message-driven
   - name: Pool Create Count
-    attribute:    pool-create-count
+    attribute: pool-create-count
     metric-family: wildfly_ejb_pool_create_count
     metric-labels:
       type: message-driven
   - name: Pool Current Size
-    attribute:    pool-current-size
+    attribute: pool-current-size
     metric-family: wildfly_ejb_pool_current_size
     metric-labels:
       type: message-driven
   - name: Pool Max Size
-    attribute:    pool-max-size
+    attribute: pool-max-size
     metric-family: wildfly_ejb_pool_max_size
     metric-labels:
       type: message-driven
   - name: Pool Remove Count
-    attribute:    pool-remove-count
+    attribute: pool-remove-count
     metric-family: wildfly_ejb_pool_remove_count
     metric-labels:
       type: message-driven
@@ -262,48 +262,48 @@ metric-set-dmr:
 - name: Stateless Session EJB Metrics
   metric-dmr:
   - name: Execution Time
-    attribute:    execution-time
+    attribute: execution-time
     metric-family: wildfly_ejb_execution_time
     metric-labels:
       type: stateless-session
   - name: Invocations
-    attribute:    invocations
-    metric-type:  counter
+    attribute: invocations
+    metric-type: counter
     metric-family: wildfly_ejb_invocations
     metric-labels:
       type: stateless-session
   - name: Peak Concurrent Invocations
-    attribute:    peak-concurrent-invocations
+    attribute: peak-concurrent-invocations
     metric-family: wildfly_ejb_peak_concurrent_invocations
     metric-labels:
       type: stateless-session
   - name: Wait Time
-    attribute:    wait-time
+    attribute: wait-time
     metric-family: wildfly_ejb_wait_time
     metric-labels:
       type: stateless-session
   - name: Pool Available Count
-    attribute:    pool-available-count
+    attribute: pool-available-count
     metric-family: wildfly_ejb_pool_available_count
     metric-labels:
       type: stateless-session
   - name: Pool Create Count
-    attribute:    pool-create-count
+    attribute: pool-create-count
     metric-family: wildfly_ejb_pool_create_count
     metric-labels:
       type: stateless-session
   - name: Pool Current Size
-    attribute:    pool-current-size
+    attribute: pool-current-size
     metric-family: wildfly_ejb_pool_current_size
     metric-labels:
       type: stateless-session
   - name: Pool Max Size
-    attribute:    pool-max-size
+    attribute: pool-max-size
     metric-family: wildfly_ejb_pool_max_size
     metric-labels:
       type: stateless-session
   - name: Pool Remove Count
-    attribute:    pool-remove-count
+    attribute: pool-remove-count
     metric-family: wildfly_ejb_pool_remove_count
     metric-labels:
       type: stateless-session
@@ -311,33 +311,33 @@ metric-set-dmr:
 - name: Stateful Session EJB Metrics
   metric-dmr:
   - name: Execution Time
-    attribute:    execution-time
+    attribute: execution-time
     metric-family: wildfly_ejb_execution_time
     metric-labels:
       type: stateful-session
   - name: Invocations
-    attribute:    invocations
-    metric-type:  counter
+    attribute: invocations
+    metric-type: counter
     metric-family: wildfly_ejb_invocations
     metric-labels:
       type: stateful-session
   - name: Peak Concurrent Invocations
-    attribute:    peak-concurrent-invocations
+    attribute: peak-concurrent-invocations
     metric-family: wildfly_ejb_peak_concurrent_invocations
     metric-labels:
       type: stateful-session
   - name: Wait Time
-    attribute:    wait-time
+    attribute: wait-time
     metric-family: wildfly_ejb_wait_time
     metric-labels:
       type: stateful-session
   - name: Cache Size
-    attribute:    cache-size
+    attribute: cache-size
     metric-family: wildfly_ejb_cache_size
     metric-labels:
       type: stateful-session
   - name: Total Size
-    attribute:    total-size
+    attribute: total-size
     metric-family: wildfly_ejb_total_size
     metric-labels:
       type: stateful-session
@@ -345,195 +345,195 @@ metric-set-dmr:
 - name: Datasource JDBC Metrics
   metric-dmr:
   - name: Prepared Statement Cache Access Count
-    path:         "/statistics=jdbc"
-    attribute:    PreparedStatementCacheAccessCount
+    path: /statistics=jdbc
+    attribute: PreparedStatementCacheAccessCount
     metric-family: wildfly_datasource_jdbc_prepared_statement_cache_access_count
   - name: Prepared Statement Cache Add Count
-    path:         "/statistics=jdbc"
-    attribute:    PreparedStatementCacheAddCount
+    path: /statistics=jdbc
+    attribute: PreparedStatementCacheAddCount
     metric-family: wildfly_datasource_jdbc_prepared_statement_cache_add_count
   - name: Prepared Statement Cache Current Size
-    path:         "/statistics=jdbc"
-    attribute:    PreparedStatementCacheCurrentSize
+    path: /statistics=jdbc
+    attribute: PreparedStatementCacheCurrentSize
     metric-family: wildfly_datasource_jdbc_prepared_statement_cache_current_size
   - name: Prepared Statement Cache Delete Count
-    path:         "/statistics=jdbc"
-    attribute:    PreparedStatementCacheDeleteCount
+    path: /statistics=jdbc
+    attribute: PreparedStatementCacheDeleteCount
     metric-family: wildfly_datasource_jdbc_prepared_statement_cache_delete_count
   - name: Prepared Statement Cache Hit Count
-    path:         "/statistics=jdbc"
-    attribute:    PreparedStatementCacheHitCount
+    path: /statistics=jdbc
+    attribute: PreparedStatementCacheHitCount
     metric-family: wildfly_datasource_jdbc_prepared_statement_cache_hit_count
   - name: Prepared Statement Cache Miss Count
-    path:         "/statistics=jdbc"
-    attribute:    PreparedStatementCacheMissCount
+    path: /statistics=jdbc
+    attribute: PreparedStatementCacheMissCount
     metric-family: wildfly_datasource_jdbc_prepared_statement_cache_miss_count
 
 - name: Datasource Pool Metrics
   metric-dmr:
   - name: Active Count
-    path:         "/statistics=pool"
-    attribute:    ActiveCount
+    path: /statistics=pool
+    attribute: ActiveCount
     metric-family: wildfly_datasorce_pool_active_count
   - name: Available Count
-    path:         "/statistics=pool"
-    attribute:    AvailableCount
+    path: /statistics=pool
+    attribute: AvailableCount
     metric-family: wildfly_datasorce_pool_available_count
   - name: Average Blocking Time
-    path:         "/statistics=pool"
-    attribute:    AverageBlockingTime
+    path: /statistics=pool
+    attribute: AverageBlockingTime
     metric-family: wildfly_datasorce_pool_average_blocking_time
   - name: Average Creation Time
-    path:         "/statistics=pool"
-    attribute:    AverageCreationTime
+    path: /statistics=pool
+    attribute: AverageCreationTime
     metric-family: wildfly_datasorce_pool_average_creation_time
   - name: Created Count
-    path:         "/statistics=pool"
-    attribute:    CreatedCount
+    path: /statistics=pool
+    attribute: CreatedCount
     metric-family: wildfly_datasorce_pool_created_count
   - name: Destroyed Count
-    path:         "/statistics=pool"
-    attribute:    DestroyedCount
+    path: /statistics=pool
+    attribute: DestroyedCount
     metric-family: wildfly_datasorce_pool_destroyed_count
   - name: In Use Count
-    path:         "/statistics=pool"
-    attribute:    InUseCount
+    path: /statistics=pool
+    attribute: InUseCount
     metric-family: wildfly_datasorce_pool_in_use_count
   - name: Max Creation Time
-    path:         "/statistics=pool"
-    attribute:    MaxCreationTime
+    path: /statistics=pool
+    attribute: MaxCreationTime
     metric-family: wildfly_datasorce_pool_max_creation_time
   - name: Max Used Count
-    path:         "/statistics=pool"
-    attribute:    MaxUsedCount
+    path: /statistics=pool
+    attribute: MaxUsedCount
     metric-family: wildfly_datasorce_pool_max_used_count
   - name: Max Wait Count
-    path:         "/statistics=pool"
-    attribute:    MaxWaitCount
+    path: /statistics=pool
+    attribute: MaxWaitCount
     metric-family: wildfly_datasorce_pool_max_wait_count
   - name: Max Wait Time
-    path:         "/statistics=pool"
-    attribute:    MaxWaitTime
+    path: /statistics=pool
+    attribute: MaxWaitTime
     metric-family: wildfly_datasorce_pool_max_wait_time
   - name: Timed Out
-    path:         "/statistics=pool"
-    attribute:    TimedOut
+    path: /statistics=pool
+    attribute: TimedOut
     metric-family: wildfly_datasorce_pool_timed_out
   - name: Total Blocking Time
-    path:         "/statistics=pool"
-    attribute:    TotalBlockingTime
+    path: /statistics=pool
+    attribute: TotalBlockingTime
     metric-family: wildfly_datasorce_pool_total_blocking_time
   - name: Total Creation Time
-    path:         "/statistics=pool"
-    attribute:    TotalCreationTime
+    path: /statistics=pool
+    attribute: TotalCreationTime
     metric-family: wildfly_datasorce_pool_total_creation_time
 - name: Transactions Metrics
   metric-dmr:
   - name: Number of Aborted Transactions
-    attribute:    number-of-aborted-transactions
-    metric-type:  counter
+    attribute: number-of-aborted-transactions
+    metric-type: counter
     metric-family: wildfly_transactions_aborted_transactions
   - name: Number of Application Rollbacks
-    attribute:    number-of-application-rollbacks
-    metric-type:  counter
+    attribute: number-of-application-rollbacks
+    metric-type: counter
     metric-family: wildfly_transactions_application_rollbacks
   - name: Number of Committed Transactions
-    attribute:    number-of-committed-transactions
-    metric-type:  counter
+    attribute: number-of-committed-transactions
+    metric-type: counter
     metric-family: wildfly_transactions_committed_transactions
   - name: Number of Heuristics
-    attribute:    number-of-heuristics
-    metric-type:  counter
+    attribute: number-of-heuristics
+    metric-type: counter
     metric-family: wildfly_transactions_heuristics
   - name: Number of In-Flight Transactions
-    attribute:    number-of-inflight-transactions
+    attribute: number-of-inflight-transactions
     metric-family: wildfly_transactions_inflight_transactions
   - name: Number of Nested Transactions
-    attribute:    number-of-nested-transactions
-    metric-type:  counter
+    attribute: number-of-nested-transactions
+    metric-type: counter
     metric-family: wildfly_transactions_nested_transactions
   - name: Number of Resource Rollbacks
-    attribute:    number-of-resource-rollbacks
-    metric-type:  counter
+    attribute: number-of-resource-rollbacks
+    metric-type: counter
     metric-family: wildfly_transactions_resource_rollbacks
   - name: Number of Timed Out Transactions
-    attribute:    number-of-timed-out-transactions
-    metric-type:  counter
+    attribute: number-of-timed-out-transactions
+    metric-type: counter
     metric-family: wildfly_transactions_timed_out_transactions
   - name: Number of Transactions
-    attribute:    number-of-transactions
-    metric-type:  counter
+    attribute: number-of-transactions
+    metric-type: counter
     metric-family: wildfly_transactions_transactions
 
 - name: JMS Queue Metrics
   metric-dmr:
   - name: Consumer Count
-    attribute:    consumer-count
+    attribute: consumer-count
     metric-family: wildfly_messaging_consumer_count
   - name: Delivering Count
-    attribute:    delivering-count
+    attribute: delivering-count
     metric-family: wildfly_messaging_delivering_count
   - name: Message Count
-    attribute:    message-count
+    attribute: message-count
     metric-family: wildfly_messaging_message_count
   - name: Messages Added
-    attribute:    messages-added
-    metric-type:  counter
+    attribute: messages-added
+    metric-type: counter
     metric-family: wildfly_messaging_messages_added
   - name: Scheduled Count
-    attribute:    scheduled-count
+    attribute: scheduled-count
     metric-family: wildfly_messaging_scheduled_count
 
 - name: JMS Topic Metrics
   metric-dmr:
   - name: Durable Message Count
-    attribute:    durable-message-count
+    attribute: durable-message-count
     metric-family: wildfly_messaging_durable_message_count
   - name: Durable Subscription Count
-    attribute:    durable-subscription-count
+    attribute: durable-subscription-count
     metric-family: wildfly_messaging_durable_subscription_count
   - name: Delivering Count
-    attribute:    delivering-count
+    attribute: delivering-count
     metric-family: wildfly_messaging_delivering_count
   - name: Message Count
-    attribute:    message-count
+    attribute: message-count
     metric-family: wildfly_messaging_message_count
   - name: Messages Added
-    attribute:    messages-added
-    metric-type:  counter
+    attribute: messages-added
+    metric-type: counter
     metric-family: wildfly_messaging_messages_added
   - name: Non-Durable Message Count
-    attribute:    non-durable-message-count
+    attribute: non-durable-message-count
     metric-family: wildfly_messaging_non_durable_message_count
   - name: Non-Durable Subscription Count
-    attribute:    non-durable-subscription-count
+    attribute: non-durable-subscription-count
     metric-family: wildfly_messaging_non_durable_subscription_count
   - name: Subscription Count
-    attribute:    subscription-count
+    attribute: subscription-count
     metric-family: wildfly_messaging_subscription_count
 
 - name: Deployment Status
   metric-dmr:
   - name: Deployment Status
-    attribute:    status
+    attribute: status
     metric-family: wildfly_deployment_availability
 
 - name: Server Availability
   metric-dmr:
   - name: Server Availability
-    attribute:    server-status
+    attribute: server-status
     metric-family: wildfly_server_availability
 
 - name: Domain Host Availability
   metric-dmr:
   - name: Domain Host Availability
-    attribute:    host-state
+    attribute: host-state
     metric-family: wildfly_domain_host_availability
 
 - name: Domain Server Availability
   metric-dmr:
   - name: Domain Server Availability
-    attribute:    status
+    attribute: status
     metric-family: wildfly_domain_host_server_availability
 
 resource-type-set-dmr:
@@ -561,54 +561,54 @@ resource-type-set-dmr:
       attribute: server-state
     - name: Home Directory
       attribute: home-dir
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     - name: Node Name
       attribute: node-name
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     - name: Hostname
       attribute: qualified-host-name
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     - name: Bound Address
       attribute: bound-address
-      path:     /socket-binding-group=standard-sockets/socket-binding=http
+      path: /socket-binding-group=standard-sockets/socket-binding=http
     operation-dmr:
     - name: JDR
       internal-name: generate-jdr-report
-      path:          /subsystem=jdr
+      path: /subsystem=jdr
     - name: Reload
       internal-name: reload
-      modifies:      true
+      modifies: true
       params:
       - name: admin-only
-        type:          bool
+        type: bool
         default-value: "false"
-        description:   Whether the server should start in running mode ADMIN_ONLY when it restarts
+        description: Whether the server should start in running mode ADMIN_ONLY when it restarts
       - name: use-current-server-config
-        type:          bool
+        type: bool
         default-value: "false"
     - name: Shutdown
       internal-name: shutdown
-      modifies:      true
+      modifies: true
       params:
       - name: restart
-        type:          bool
+        type: bool
         default-value: "false"
-        description:   "Should the server be restarted after shutdown?"
+        description: "Should the server be restarted after shutdown?"
     - name: Deploy
       internal-name: deploy
-      modifies:      true
+      modifies: true
     - name: Undeploy
       internal-name: undeploy
-      modifies:      true
+      modifies: true
     - name: Enable Deployment
       internal-name: enable-deployment
-      modifies:      true
+      modifies: true
     - name: Disable Deployment
       internal-name: disable-deployment
-      modifies:      true
+      modifies: true
     - name: Restart Deployment
       internal-name: restart-deployment
-      modifies:      true
+      modifies: true
 
 - name: Domain Environment
   resource-type-dmr:
@@ -628,28 +628,28 @@ resource-type-set-dmr:
     operation-dmr:
     - name: Restart Servers
       internal-name: restart-servers
-      modifies:      true
+      modifies: true
     - name: Start Servers
       internal-name: start-servers
-      modifies:      true
+      modifies: true
     - name: Stop Servers
       internal-name: stop-servers
-      modifies:      true
+      modifies: true
     - name: Deploy
       internal-name: deploy
-      modifies:      true
+      modifies: true
     - name: Undeploy
       internal-name: undeploy
-      modifies:      true
+      modifies: true
     - name: Enable Deployment
       internal-name: enable-deployment
-      modifies:      true
+      modifies: true
     - name: Disable Deployment
       internal-name: disable-deployment
-      modifies:      true
+      modifies: true
     - name: Restart Deployment
       internal-name: restart-deployment
-      modifies:      true
+      modifies: true
 
   - name: Domain Profile
     resource-name-template: "%-"
@@ -671,13 +671,13 @@ resource-type-set-dmr:
     operation-dmr:
     - name: Restart Servers
       internal-name: restart-servers
-      modifies:      true
+      modifies: true
     - name: Start Servers
       internal-name: start-servers
-      modifies:      true
+      modifies: true
     - name: Stop Servers
       internal-name: stop-servers
-      modifies:      true
+      modifies: true
 
   - name: Domain Host
     resource-name-template: "%-"
@@ -709,17 +709,17 @@ resource-type-set-dmr:
       attribute: server-state
     - name: Home Directory
       attribute: home-dir
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     operation-dmr:
     - name: Reload
       internal-name: reload
-      modifies:      true
+      modifies: true
     - name: Shutdown
       internal-name: shutdown
-      modifies:      true
+      modifies: true
       params:
       - name: restart
-        type:        bool
+        type: bool
         description: If true, once shutdown the host controller will be restarted again.
 
   - name: Domain WildFly Server
@@ -756,23 +756,23 @@ resource-type-set-dmr:
       attribute: server-state
     - name: Hostname
       attribute: qualified-host-name
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     - name: Node Name
       attribute: node-name
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     - name: Initial Running Mode
       attribute: initial-running-mode
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     - name: Base Directory
       attribute: base-dir
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     - name: Bound Address
       attribute: bound-address
-      path:     /socket-binding-group=full-sockets/socket-binding=http
+      path: /socket-binding-group=full-sockets/socket-binding=http
     operation-dmr:
     - name: JDR
       internal-name: generate-jdr-report
-      path:          /subsystem=jdr
+      path: /subsystem=jdr
 
   - name: Domain WildFly Server Controller
     resource-name-template: "%-"
@@ -793,40 +793,40 @@ resource-type-set-dmr:
     operation-dmr:
     - name: Destroy
       internal-name: destroy
-      modifies:      true
+      modifies: true
     - name: Kill
       internal-name: kill
-      modifies:      true
+      modifies: true
     - name: Restart
       internal-name: restart
-      modifies:      true
+      modifies: true
       params:
       - name: server
         description: The name of the server.
       - name: blocking
-        type:          bool
+        type: bool
         default-value: "false"
-        description:   Wait until the servers are stopped before returning from the operation.
+        description: Wait until the servers are stopped before returning from the operation.
     - name: Start
       internal-name: start
-      modifies:      true
+      modifies: true
       params:
       - name: server
         description: The name of the server.
       - name: blocking
-        type:          bool
+        type: bool
         default-value: "false"
-        description:   Wait until the servers are stopped before returning from the operation.
+        description: Wait until the servers are stopped before returning from the operation.
     - name: Stop
       internal-name: stop
-      modifies:      true
+      modifies: true
       params:
       - name: server
         description: The name of the server.
       - name: blocking
-        type:          bool
+        type: bool
         default-value: "false"
-        description:   Wait until the servers are stopped before returning from the operation.
+        description: Wait until the servers are stopped before returning from the operation.
 
 - name: Web Subsystem
   resource-type-dmr:
@@ -955,7 +955,7 @@ resource-type-set-dmr:
     - name: Security Domain
       attribute: security-domain
     - name: Connection Properties
-      path:      "/connection-properties=*"
+      path: "/connection-properties=*"
       attribute: value
 
 - name: XA Datasource
@@ -987,7 +987,7 @@ resource-type-set-dmr:
     - name: Security Domain
       attribute: security-domain
     - name: Datasource Properties
-      path:      "/xa-datasource-properties=*"
+      path: "/xa-datasource-properties=*"
       attribute: value
 
 - name: JDBC Driver
@@ -1012,7 +1012,7 @@ resource-type-set-dmr:
   resource-type-dmr:
   - name: Transaction Manager
     resource-name-template: Transaction Manager
-    path: "/subsystem=transactions"
+    path: /subsystem=transactions
     parents:
     - WildFly Server
     - Domain WildFly Server
@@ -1096,27 +1096,27 @@ resource-type-set-dmr:
 - name: Clustering
   resource-type-dmr:
   - name: ModCluster
-    resource-name-template: "ModCluster"
-    path:                   "/subsystem=modcluster"
+    resource-name-template: ModCluster
+    path: /subsystem=modcluster
     parents:
     - WildFly Server
     - Domain WildFly Server
     resource-config-dmr:
     - name: Connector
       attribute: connector
-      path:      "/mod-cluster-config=configuration"
+      path: /mod-cluster-config=configuration
     - name: Advertise Socket Binding
       attribute: advertise-socket
-      path:      "/mod-cluster-config=configuration"
+      path: /mod-cluster-config=configuration
   - name: JGroups
-    resource-name-template: "JGroups"
-    path:                   "/subsystem=jgroups"
+    resource-name-template: JGroups
+    path: /subsystem=jgroups
     parents:
     - WildFly Server
     - Domain WildFly Server
   - name: JGroups Channel
     resource-name-template: "%-"
-    path:                   "/channel=*"
+    path: "/channel=*"
     parents:
     - JGroups
     resource-config-dmr:
@@ -1128,14 +1128,14 @@ resource-type-set-dmr:
       attribute: view
 
   - name: Infinispan
-    resource-name-template: "Infinispan"
-    path:                   "/subsystem=infinispan"
+    resource-name-template: Infinispan
+    path: /subsystem=infinispan
     parents:
     - WildFly Server
     - Domain WildFly Server
   - name: Infinispan Cache Container
     resource-name-template: "%-"
-    path:                   "/cache-container=*"
+    path: "/cache-container=*"
     parents:
     - Infinispan
     resource-config-dmr:
@@ -1152,21 +1152,21 @@ metric-set-jmx:
 - name: Runtime Metrics
   metric-jmx:
   - name: VM Uptime
-    attribute:    Uptime
+    attribute: Uptime
     metric-units: milliseconds
-    metric-type:  counter
+    metric-type: counter
     metric-family: TODO
   - name: Used Heap Memory
-    object-name:  java.lang:type=Memory
-    attribute:    HeapMemoryUsage#used
+    object-name: java.lang:type=Memory
+    attribute: HeapMemoryUsage#used
     metric-units: bytes
-    metric-type:  gauge
+    metric-type: gauge
     metric-family: jvm_memory_bytes_used
     metric-labels:
       area: heap
   - name: Aggregate GC Collection Time
-    object-name:  "java.lang:type=GarbageCollector,name=*"
-    attribute:    CollectionTime
+    object-name: "java.lang:type=GarbageCollector,name=*"
+    attribute: CollectionTime
     metric-units: seconds
     metric-family: jvm_gc_collection_seconds_sum
     metric-expression: sum($metric)
@@ -1174,79 +1174,79 @@ metric-set-jmx:
 - name: Memory Pool Metrics
   metric-jmx:
   - name: Initial
-    attribute:    Usage#init
+    attribute: Usage#init
     metric-units: bytes
-    metric-type:  gauge
+    metric-type: gauge
     metric-family: jvm_memory_pool_bytes_init
   - name: Used
-    attribute:    Usage#used
+    attribute: Usage#used
     metric-units: bytes
-    metric-type:  gauge
+    metric-type: gauge
     metric-family: jvm_memory_pool_bytes_used
   - name: Committed
-    attribute:    Usage#committed
+    attribute: Usage#committed
     metric-units: bytes
-    metric-type:  gauge
+    metric-type: gauge
     metric-family: jvm_memory_pool_bytes_committed
   - name: Max
-    attribute:    Usage#max
+    attribute: Usage#max
     metric-units: bytes
-    metric-type:  gauge
+    metric-type: gauge
     metric-family: jvm_memory_pool_bytes_max
 
 - name: Platform Operating System Metrics
   metric-jmx:
   - name: System CPU Load
-    attribute:     System CPU Load
-    metric-type:   gauge
+    attribute: System CPU Load
+    metric-type: gauge
     metric-family: hawkular_platform_operatingsystem_system_cpu_load
   - name: System Load Average
-    attribute:     System Load Average
-    metric-type:   gauge
+    attribute: System Load Average
+    metric-type: gauge
     metric-family: hawkular_platform_operatingsystem_system_load_average
   - name: Process Count
-    attribute:     Process Count
-    metric-type:   gauge
+    attribute: Process Count
+    metric-type: gauge
     metric-family: hawkular_platform_operatingsystem_process_count
 
 - name: Platform File Store Metrics
   metric-jmx:
   - name: Usable Space
-    attribute:     Usable Space
-    metric-type:   gauge
+    attribute: Usable Space
+    metric-type: gauge
     metric-family: hawkular_platform_filestore_usable_space
   - name: Total Space
-    attribute:     Total Space
-    metric-type:   gauge
+    attribute: Total Space
+    metric-type: gauge
     metric-family: hawkular_platform_filestore_total_space
 
 - name: Platform Memory Metrics
   metric-jmx:
   - name: Available Memory
-    attribute:     Available Memory
-    metric-type:   gauge
+    attribute: Available Memory
+    metric-type: gauge
     metric-family: hawkular_platform_memory_available_memory
   - name: Total Memory
-    attribute:     Total Memory
-    metric-type:   gauge
+    attribute: Total Memory
+    metric-type: gauge
     metric-family: hawkular_platform_memory_total_memory
 
 - name: Platform Processor Metrics
   metric-jmx:
   - name: CPU Usage
-    attribute:     CPU Usage
-    metric-type:   gauge
+    attribute: CPU Usage
+    metric-type: gauge
     metric-family: hawkular_platform_processor_cpu_usage
 
 - name: Platform Power Source Metrics
   metric-jmx:
   - name: Remaining Capacity
-    attribute:     Remaining Capacity
-    metric-type:   gauge
+    attribute: Remaining Capacity
+    metric-type: gauge
     metric-family: hawkular_platform_powersource_remaining_capacity
   - name: Time Remaining
-    attribute:     Time Remaining
-    metric-type:   gauge
+    attribute: Time Remaining
+    metric-type: gauge
     metric-family: hawkular_platform_powersource_time_remaining
 
 resource-type-set-jmx:
@@ -1259,10 +1259,10 @@ resource-type-set-jmx:
     - Runtime Metrics
     resource-config-jmx:
     - name: OS Name
-      attribute:   Name
+      attribute: Name
       object-name: java.lang:type=OperatingSystem
     - name: Java VM Name
-      attribute:   VmName
+      attribute: VmName
 
 - name: Memory Pool
   resource-type-jmx:
@@ -1280,8 +1280,8 @@ resource-type-set-jmx:
 - name: Hawkular
   resource-type-jmx:
   - name: Hawkular Java Agent
-    resource-name-template: "Hawkular Java Agent"
-    object-name: "org.hawkular.agent:type=hawkular-javaagent"
+    resource-name-template: Hawkular Java Agent
+    object-name: org.hawkular.agent:type=hawkular-javaagent
     resource-config-jmx:
     - name: Immutable
       attribute: Immutable
@@ -1307,7 +1307,7 @@ resource-type-set-jmx:
   resource-type-jmx:
   - name: Platform Operating System
     resource-name-template: Platform Operating System
-    object-name: "org.hawkular.agent:type=platform,subtype=operatingsystem"
+    object-name: org.hawkular.agent:type=platform,subtype=operatingsystem
     resource-config-jmx:
     - name: Machine Id
       attribute: Machine Id
@@ -1330,7 +1330,7 @@ resource-type-set-jmx:
     parents:
     - Platform Operating System
     resource-name-template: Platform Memory
-    object-name: "org.hawkular.agent:type=platform,subtype=memory"
+    object-name: org.hawkular.agent:type=platform,subtype=memory
     metric-sets:
     - Platform Memory Metrics
   - name: Platform Processor

--- a/hawkular-inventory-parent/hawkular-inventory-service/src/main/resources/WF10-inventory.yml
+++ b/hawkular-inventory-parent/hawkular-inventory-service/src/main/resources/WF10-inventory.yml
@@ -26,54 +26,54 @@ metric-set-dmr:
   metric-dmr:
   - name: Heap Used
     metric-units: bytes
-    metric-type:  gauge
-    path:         /core-service=platform-mbean/type=memory
-    attribute:    heap-memory-usage#used
+    metric-type: gauge
+    path: /core-service=platform-mbean/type=memory
+    attribute: heap-memory-usage#used
     metric-family: jvm_memory_bytes_used
     metric-labels:
       area: heap
   - name: Heap Committed
     metric-units: bytes
-    metric-type:  gauge
-    path:         /core-service=platform-mbean/type=memory
-    attribute:    heap-memory-usage#committed
+    metric-type: gauge
+    path: /core-service=platform-mbean/type=memory
+    attribute: heap-memory-usage#committed
     metric-family: jvm_memory_bytes_committed
     metric-labels:
       area: heap
   - name: Heap Max
     metric-units: bytes
-    metric-type:  gauge
-    path:         /core-service=platform-mbean/type=memory
-    attribute:    heap-memory-usage#max
+    metric-type: gauge
+    path: /core-service=platform-mbean/type=memory
+    attribute: heap-memory-usage#max
     metric-family: jvm_memory_bytes_max
     metric-labels:
       area: heap
   - name: NonHeap Used
     metric-units: bytes
-    path:         /core-service=platform-mbean/type=memory
-    attribute:    non-heap-memory-usage#used
+    path: /core-service=platform-mbean/type=memory
+    attribute: non-heap-memory-usage#used
     metric-family: jvm_memory_bytes_used
     metric-labels:
       area: nonheap
   - name: NonHeap Committed
     metric-units: bytes
-    path:         /core-service=platform-mbean/type=memory
-    attribute:    non-heap-memory-usage#committed
+    path: /core-service=platform-mbean/type=memory
+    attribute: non-heap-memory-usage#committed
     metric-family: jvm_memory_bytes_committed
     metric-labels:
       area: nonheap
   - name: NonHeap Max
     metric-units: bytes
-    path:         /core-service=platform-mbean/type=memory
-    attribute:    non-heap-memory-usage#max
+    path: /core-service=platform-mbean/type=memory
+    attribute: non-heap-memory-usage#max
     metric-family: jvm_memory_bytes_max
     metric-labels:
       area: nonheap
   - name: Accumulated GC Duration
     metric-units: seconds
-    metric-type:  counter
-    path:         "/core-service=platform-mbean/type=garbage-collector/name=*"
-    attribute:    collection-time
+    metric-type: counter
+    path: "/core-service=platform-mbean/type=garbage-collector/name=*"
+    attribute: collection-time
     metric-family: jvm_gc_collection_seconds_sum
     metric-expression: sum($metric)
     # no metric-labels because we want to aggregate across all of them
@@ -81,41 +81,41 @@ metric-set-dmr:
 - name: WildFly Threading Metrics
   metric-dmr:
   - name: Thread Count
-    metric-type:  gauge
-    path:         /core-service=platform-mbean/type=threading
-    attribute:    thread-count
+    metric-type: gauge
+    path: /core-service=platform-mbean/type=threading
+    attribute: thread-count
     metric-family: jvm_threads_current
 
 - name: Undertow Aggregated Web Metrics
   metric-dmr:
   - name: Aggregated Active Web Sessions
-    path:       "/deployment=*/subsystem=undertow"
-    attribute:  active-sessions
+    path: "/deployment=*/subsystem=undertow"
+    attribute: active-sessions
     metric-family: wildfly_deployment_active_sessions
     metric-expression: sum($metric)
   - name: Aggregated Max Active Web Sessions
-    path:       "/deployment=*/subsystem=undertow"
-    attribute:  max-active-sessions
+    path: "/deployment=*/subsystem=undertow"
+    attribute: max-active-sessions
     metric-family: wildfly_deployment_max_active_sessions
     metric-expression: sum($metric)
   - name: Aggregated Expired Web Sessions
-    path:       "/deployment=*/subsystem=undertow"
-    attribute:  expired-sessions
+    path: "/deployment=*/subsystem=undertow"
+    attribute: expired-sessions
     metric-family: wildfly_deployment_expired_sessions
     metric-expression: sum($metric)
   - name: Aggregated Rejected Web Sessions
-    path:       "/deployment=*/subsystem=undertow"
-    attribute:  rejected-sessions
+    path: "/deployment=*/subsystem=undertow"
+    attribute: rejected-sessions
     metric-family: wildfly_deployment_rejected_sessions
     metric-expression: sum($metric)
   - name: Aggregated Servlet Request Time
-    path:       "/deployment=*/subsystem=undertow/servlet=*"
-    attribute:  total-request-time
+    path: "/deployment=*/subsystem=undertow/servlet=*"
+    attribute: total-request-time
     metric-family: wildfly_servlet_total_request_time
     metric-expression: sum($metric)
   - name: Aggregated Servlet Request Count
-    path:       "/deployment=*/subsystem=undertow/servlet=*"
-    attribute:  request-count
+    path: "/deployment=*/subsystem=undertow/servlet=*"
+    attribute: request-count
     metric-family: wildfly_servlet_request_count
     metric-expression: sum($metric)
 
@@ -123,11 +123,11 @@ metric-set-dmr:
   metric-dmr:
   - name: Request Count
     attribute: request-count
-    metric-type:  counter
+    metric-type: counter
     metric-family: wildfly_undertow_request_count
   - name: Error Count
     attribute: error-count
-    metric-type:  counter
+    metric-type: counter
     metric-family: wildfly_undertow_error_count
   - name: Bytes Sent
     attribute: bytes-sent
@@ -145,68 +145,68 @@ metric-set-dmr:
 - name: Undertow Metrics
   metric-dmr:
   - name: Active Sessions
-    path:       "/subsystem=undertow"
-    attribute:  active-sessions
+    path: /subsystem=undertow
+    attribute: active-sessions
     metric-family: wildfly_deployment_active_sessions
   - name: Sessions Created
-    path:       "/subsystem=undertow"
-    attribute:  sessions-created
+    path: /subsystem=undertow
+    attribute: sessions-created
     metric-type: counter
     metric-family: wildfly_deployment_sessions_created
   - name: Expired Sessions
-    path:       "/subsystem=undertow"
-    attribute:  expired-sessions
+    path: /subsystem=undertow
+    attribute: expired-sessions
     metric-type: counter
     metric-family: wildfly_deployment_expired_sessions
   - name: Rejected Sessions
-    path:       "/subsystem=undertow"
-    attribute:  rejected-sessions
+    path: /subsystem=undertow
+    attribute: rejected-sessions
     metric-type: counter
     metric-family: wildfly_deployment_rejected_sessions
   - name: Max Active Sessions
-    path:       "/subsystem=undertow"
-    attribute:  max-active-sessions
+    path: /subsystem=undertow
+    attribute: max-active-sessions
     metric-family: wildfly_deployment_max_active_sessions
 
 - name: Servlet Metrics
   metric-dmr:
   - name: Max Request Time
-    attribute:    max-request-time
+    attribute: max-request-time
     metric-units: milliseconds
     metric-family: wildfly_servlet_max_request_time
   - name: Min Request Time
-    attribute:    min-request-time
+    attribute: min-request-time
     metric-units: milliseconds
     metric-family: wildfly_servlet_min_request_time
   - name: Total Request Time
-    attribute:    total-request-time
+    attribute: total-request-time
     metric-units: milliseconds
     metric-family: wildfly_servlet_total_request_time
   - name: Request Count
-    attribute:    request-count
-    metric-type:  counter
+    attribute: request-count
+    metric-type: counter
     metric-family: wildfly_servlet_request_count
 
 - name: Singleton EJB Metrics
   metric-dmr:
   - name: Execution Time
-    attribute:    execution-time
+    attribute: execution-time
     metric-family: wildfly_ejb_execution_time
     metric-labels:
       type: singleton
   - name: Invocations
-    attribute:    invocations
-    metric-type:  counter
+    attribute: invocations
+    metric-type: counter
     metric-family: wildfly_ejb_invocations
     metric-labels:
       type: singleton
   - name: Peak Concurrent Invocations
-    attribute:    peak-concurrent-invocations
+    attribute: peak-concurrent-invocations
     metric-family: wildfly_ejb_peak_concurrent_invocations
     metric-labels:
       type: singleton
   - name: Wait Time
-    attribute:    wait-time
+    attribute: wait-time
     metric-family: wildfly_ejb_wait_time
     metric-labels:
       type: singleton
@@ -214,48 +214,48 @@ metric-set-dmr:
 - name: Message Driven EJB Metrics
   metric-dmr:
   - name: Execution Time
-    attribute:    execution-time
+    attribute: execution-time
     metric-family: wildfly_ejb_execution_time
     metric-labels:
       type: message-driven
   - name: Invocations
-    attribute:    invocations
-    metric-type:  counter
+    attribute: invocations
+    metric-type: counter
     metric-family: wildfly_ejb_invocations
     metric-labels:
       type: message-driven
   - name: Peak Concurrent Invocations
-    attribute:    peak-concurrent-invocations
+    attribute: peak-concurrent-invocations
     metric-family: wildfly_ejb_peak_concurrent_invocations
     metric-labels:
       type: message-driven
   - name: Wait Time
-    attribute:    wait-time
+    attribute: wait-time
     metric-family: wildfly_ejb_wait_time
     metric-labels:
       type: message-driven
   - name: Pool Available Count
-    attribute:    pool-available-count
+    attribute: pool-available-count
     metric-family: wildfly_ejb_pool_available_count
     metric-labels:
       type: message-driven
   - name: Pool Create Count
-    attribute:    pool-create-count
+    attribute: pool-create-count
     metric-family: wildfly_ejb_pool_create_count
     metric-labels:
       type: message-driven
   - name: Pool Current Size
-    attribute:    pool-current-size
+    attribute: pool-current-size
     metric-family: wildfly_ejb_pool_current_size
     metric-labels:
       type: message-driven
   - name: Pool Max Size
-    attribute:    pool-max-size
+    attribute: pool-max-size
     metric-family: wildfly_ejb_pool_max_size
     metric-labels:
       type: message-driven
   - name: Pool Remove Count
-    attribute:    pool-remove-count
+    attribute: pool-remove-count
     metric-family: wildfly_ejb_pool_remove_count
     metric-labels:
       type: message-driven
@@ -263,48 +263,48 @@ metric-set-dmr:
 - name: Stateless Session EJB Metrics
   metric-dmr:
   - name: Execution Time
-    attribute:    execution-time
+    attribute: execution-time
     metric-family: wildfly_ejb_execution_time
     metric-labels:
       type: stateless-session
   - name: Invocations
-    attribute:    invocations
-    metric-type:  counter
+    attribute: invocations
+    metric-type: counter
     metric-family: wildfly_ejb_invocations
     metric-labels:
       type: stateless-session
   - name: Peak Concurrent Invocations
-    attribute:    peak-concurrent-invocations
+    attribute: peak-concurrent-invocations
     metric-family: wildfly_ejb_peak_concurrent_invocations
     metric-labels:
       type: stateless-session
   - name: Wait Time
-    attribute:    wait-time
+    attribute: wait-time
     metric-family: wildfly_ejb_wait_time
     metric-labels:
       type: stateless-session
   - name: Pool Available Count
-    attribute:    pool-available-count
+    attribute: pool-available-count
     metric-family: wildfly_ejb_pool_available_count
     metric-labels:
       type: stateless-session
   - name: Pool Create Count
-    attribute:    pool-create-count
+    attribute: pool-create-count
     metric-family: wildfly_ejb_pool_create_count
     metric-labels:
       type: stateless-session
   - name: Pool Current Size
-    attribute:    pool-current-size
+    attribute: pool-current-size
     metric-family: wildfly_ejb_pool_current_size
     metric-labels:
       type: stateless-session
   - name: Pool Max Size
-    attribute:    pool-max-size
+    attribute: pool-max-size
     metric-family: wildfly_ejb_pool_max_size
     metric-labels:
       type: stateless-session
   - name: Pool Remove Count
-    attribute:    pool-remove-count
+    attribute: pool-remove-count
     metric-family: wildfly_ejb_pool_remove_count
     metric-labels:
       type: stateless-session
@@ -312,33 +312,33 @@ metric-set-dmr:
 - name: Stateful Session EJB Metrics
   metric-dmr:
   - name: Execution Time
-    attribute:    execution-time
+    attribute: execution-time
     metric-family: wildfly_ejb_execution_time
     metric-labels:
       type: stateful-session
   - name: Invocations
-    attribute:    invocations
-    metric-type:  counter
+    attribute: invocations
+    metric-type: counter
     metric-family: wildfly_ejb_invocations
     metric-labels:
       type: stateful-session
   - name: Peak Concurrent Invocations
-    attribute:    peak-concurrent-invocations
+    attribute: peak-concurrent-invocations
     metric-family: wildfly_ejb_peak_concurrent_invocations
     metric-labels:
       type: stateful-session
   - name: Wait Time
-    attribute:    wait-time
+    attribute: wait-time
     metric-family: wildfly_ejb_wait_time
     metric-labels:
       type: stateful-session
   - name: Cache Size
-    attribute:    cache-size
+    attribute: cache-size
     metric-family: wildfly_ejb_cache_size
     metric-labels:
       type: stateful-session
   - name: Total Size
-    attribute:    total-size
+    attribute: total-size
     metric-family: wildfly_ejb_total_size
     metric-labels:
       type: stateful-session
@@ -346,220 +346,220 @@ metric-set-dmr:
 - name: Datasource JDBC Metrics
   metric-dmr:
   - name: Prepared Statement Cache Access Count
-    path:         "/statistics=jdbc"
-    attribute:    PreparedStatementCacheAccessCount
+    path: /statistics=jdbc
+    attribute: PreparedStatementCacheAccessCount
     metric-family: wildfly_datasource_jdbc_prepared_statement_cache_access_count
   - name: Prepared Statement Cache Add Count
-    path:         "/statistics=jdbc"
-    attribute:    PreparedStatementCacheAddCount
+    path: /statistics=jdbc
+    attribute: PreparedStatementCacheAddCount
     metric-family: wildfly_datasource_jdbc_prepared_statement_cache_add_count
   - name: Prepared Statement Cache Current Size
-    path:         "/statistics=jdbc"
-    attribute:    PreparedStatementCacheCurrentSize
+    path: /statistics=jdbc
+    attribute: PreparedStatementCacheCurrentSize
     metric-family: wildfly_datasource_jdbc_prepared_statement_cache_current_size
   - name: Prepared Statement Cache Delete Count
-    path:         "/statistics=jdbc"
-    attribute:    PreparedStatementCacheDeleteCount
+    path: /statistics=jdbc
+    attribute: PreparedStatementCacheDeleteCount
     metric-family: wildfly_datasource_jdbc_prepared_statement_cache_delete_count
   - name: Prepared Statement Cache Hit Count
-    path:         "/statistics=jdbc"
-    attribute:    PreparedStatementCacheHitCount
+    path: /statistics=jdbc
+    attribute: PreparedStatementCacheHitCount
     metric-family: wildfly_datasource_jdbc_prepared_statement_cache_hit_count
   - name: Prepared Statement Cache Miss Count
-    path:         "/statistics=jdbc"
-    attribute:    PreparedStatementCacheMissCount
+    path: /statistics=jdbc
+    attribute: PreparedStatementCacheMissCount
     metric-family: wildfly_datasource_jdbc_prepared_statement_cache_miss_count
 
 - name: Datasource Pool Metrics
   metric-dmr:
   - name: Active Count
-    path:         "/statistics=pool"
-    attribute:    ActiveCount
+    path: /statistics=pool
+    attribute: ActiveCount
     metric-family: wildfly_datasorce_pool_active_count
   - name: Available Count
-    path:         "/statistics=pool"
-    attribute:    AvailableCount
+    path: /statistics=pool
+    attribute: AvailableCount
     metric-family: wildfly_datasorce_pool_available_count
   - name: Average Blocking Time
-    path:         "/statistics=pool"
-    attribute:    AverageBlockingTime
+    path: /statistics=pool
+    attribute: AverageBlockingTime
     metric-family: wildfly_datasorce_pool_average_blocking_time
   - name: Average Creation Time
-    path:         "/statistics=pool"
-    attribute:    AverageCreationTime
+    path: /statistics=pool
+    attribute: AverageCreationTime
     metric-family: wildfly_datasorce_pool_average_creation_time
   - name: Average Get Time
-    path:         "/statistics=pool"
-    attribute:    AverageGetTime
+    path: /statistics=pool
+    attribute: AverageGetTime
     metric-family: wildfly_datasorce_pool_average_get_time
   - name: Blocking Failure Count
-    path:         "/statistics=pool"
-    attribute:    BlockingFailureCount
+    path: /statistics=pool
+    attribute: BlockingFailureCount
     metric-family: wildfly_datasorce_pool_blocking_failure_count
   - name: Created Count
-    path:         "/statistics=pool"
-    attribute:    CreatedCount
+    path: /statistics=pool
+    attribute: CreatedCount
     metric-family: wildfly_datasorce_pool_created_count
   - name: Destroyed Count
-    path:         "/statistics=pool"
-    attribute:    DestroyedCount
+    path: /statistics=pool
+    attribute: DestroyedCount
     metric-family: wildfly_datasorce_pool_destroyed_count
   - name: Idle Count
-    path:         "/statistics=pool"
-    attribute:    IdleCount
+    path: /statistics=pool
+    attribute: IdleCount
     metric-family: wildfly_datasorce_pool_idle_count
   - name: In Use Count
-    path:         "/statistics=pool"
-    attribute:    InUseCount
+    path: /statistics=pool
+    attribute: InUseCount
     metric-family: wildfly_datasorce_pool_in_use_count
   - name: Max Creation Time
-    path:         "/statistics=pool"
-    attribute:    MaxCreationTime
+    path: /statistics=pool
+    attribute: MaxCreationTime
     metric-family: wildfly_datasorce_pool_max_creation_time
   - name: Max Get Time
-    path:         "/statistics=pool"
-    attribute:    MaxGetTime
+    path: /statistics=pool
+    attribute: MaxGetTime
     metric-family: wildfly_datasorce_pool_max_get_time
   - name: Max Used Count
-    path:         "/statistics=pool"
-    attribute:    MaxUsedCount
+    path: /statistics=pool
+    attribute: MaxUsedCount
     metric-family: wildfly_datasorce_pool_max_used_count
   - name: Max Wait Count
-    path:         "/statistics=pool"
-    attribute:    MaxWaitCount
+    path: /statistics=pool
+    attribute: MaxWaitCount
     metric-family: wildfly_datasorce_pool_max_wait_count
   - name: Max Wait Time
-    path:         "/statistics=pool"
-    attribute:    MaxWaitTime
+    path: /statistics=pool
+    attribute: MaxWaitTime
     metric-family: wildfly_datasorce_pool_max_wait_time
   - name: Timed Out
-    path:         "/statistics=pool"
-    attribute:    TimedOut
+    path: /statistics=pool
+    attribute: TimedOut
     metric-family: wildfly_datasorce_pool_timed_out
   - name: Total Blocking Time
-    path:         "/statistics=pool"
-    attribute:    TotalBlockingTime
+    path: /statistics=pool
+    attribute: TotalBlockingTime
     metric-family: wildfly_datasorce_pool_total_blocking_time
   - name: Total Creation Time
-    path:         "/statistics=pool"
-    attribute:    TotalCreationTime
+    path: /statistics=pool
+    attribute: TotalCreationTime
     metric-family: wildfly_datasorce_pool_total_creation_time
   - name: Total Get Time
-    path:         "/statistics=pool"
-    attribute:    TotalGetTime
+    path: /statistics=pool
+    attribute: TotalGetTime
     metric-family: wildfly_datasorce_pool_total_get_time
   - name: Wait Count
-    path:         "/statistics=pool"
-    attribute:    WaitCount
+    path: /statistics=pool
+    attribute: WaitCount
     metric-family: wildfly_datasorce_pool_wait_count
 
 - name: Transactions Metrics
   metric-dmr:
   - name: Number of Aborted Transactions
-    attribute:    number-of-aborted-transactions
-    metric-type:  counter
+    attribute: number-of-aborted-transactions
+    metric-type: counter
     metric-family: wildfly_transactions_aborted_transactions
   - name: Number of Application Rollbacks
-    attribute:    number-of-application-rollbacks
-    metric-type:  counter
+    attribute: number-of-application-rollbacks
+    metric-type: counter
     metric-family: wildfly_transactions_application_rollbacks
   - name: Number of Committed Transactions
-    attribute:    number-of-committed-transactions
-    metric-type:  counter
+    attribute: number-of-committed-transactions
+    metric-type: counter
     metric-family: wildfly_transactions_committed_transactions
   - name: Number of Heuristics
-    attribute:    number-of-heuristics
-    metric-type:  counter
+    attribute: number-of-heuristics
+    metric-type: counter
     metric-family: wildfly_transactions_heuristics
   - name: Number of In-Flight Transactions
-    attribute:    number-of-inflight-transactions
+    attribute: number-of-inflight-transactions
     metric-family: wildfly_transactions_inflight_transactions
   - name: Number of Nested Transactions
-    attribute:    number-of-nested-transactions
-    metric-type:  counter
+    attribute: number-of-nested-transactions
+    metric-type: counter
     metric-family: wildfly_transactions_nested_transactions
   - name: Number of Resource Rollbacks
-    attribute:    number-of-resource-rollbacks
-    metric-type:  counter
+    attribute: number-of-resource-rollbacks
+    metric-type: counter
     metric-family: wildfly_transactions_resource_rollbacks
   - name: Number of Timed Out Transactions
-    attribute:    number-of-timed-out-transactions
-    metric-type:  counter
+    attribute: number-of-timed-out-transactions
+    metric-type: counter
     metric-family: wildfly_transactions_timed_out_transactions
   - name: Number of Transactions
-    attribute:    number-of-transactions
-    metric-type:  counter
+    attribute: number-of-transactions
+    metric-type: counter
     metric-family: wildfly_transactions_transactions
 
 - name: JMS Queue Metrics
   metric-dmr:
   - name: Consumer Count
-    attribute:    consumer-count
+    attribute: consumer-count
     metric-family: wildfly_messaging_consumer_count
   - name: Delivering Count
-    attribute:    delivering-count
+    attribute: delivering-count
     metric-family: wildfly_messaging_delivering_count
   - name: Message Count
-    attribute:    message-count
+    attribute: message-count
     metric-family: wildfly_messaging_message_count
   - name: Messages Added
-    attribute:    messages-added
-    metric-type:  counter
+    attribute: messages-added
+    metric-type: counter
     metric-family: wildfly_messaging_messages_added
   - name: Scheduled Count
-    attribute:    scheduled-count
+    attribute: scheduled-count
     metric-family: wildfly_messaging_scheduled_count
 
 - name: JMS Topic Metrics
   metric-dmr:
   - name: Durable Message Count
-    attribute:    durable-message-count
+    attribute: durable-message-count
     metric-family: wildfly_messaging_durable_message_count
   - name: Durable Subscription Count
-    attribute:    durable-subscription-count
+    attribute: durable-subscription-count
     metric-family: wildfly_messaging_durable_subscription_count
   - name: Delivering Count
-    attribute:    delivering-count
+    attribute: delivering-count
     metric-family: wildfly_messaging_delivering_count
   - name: Message Count
-    attribute:    message-count
+    attribute: message-count
     metric-family: wildfly_messaging_message_count
   - name: Messages Added
-    attribute:    messages-added
-    metric-type:  counter
+    attribute: messages-added
+    metric-type: counter
     metric-family: wildfly_messaging_messages_added
   - name: Non-Durable Message Count
-    attribute:    non-durable-message-count
+    attribute: non-durable-message-count
     metric-family: wildfly_messaging_non_durable_message_count
   - name: Non-Durable Subscription Count
-    attribute:    non-durable-subscription-count
+    attribute: non-durable-subscription-count
     metric-family: wildfly_messaging_non_durable_subscription_count
   - name: Subscription Count
-    attribute:    subscription-count
+    attribute: subscription-count
     metric-family: wildfly_messaging_subscription_count
 
 - name: Deployment Status
   metric-dmr:
   - name: Deployment Status
-    attribute:    status
+    attribute: status
     metric-family: wildfly_deployment_availability
 
 - name: Server Availability
   metric-dmr:
   - name: Server Availability
-    attribute:    server-status
+    attribute: server-status
     metric-family: wildfly_server_availability
 
 - name: Domain Host Availability
   metric-dmr:
   - name: Domain Host Availability
-    attribute:    host-state
+    attribute: host-state
     metric-family: wildfly_domain_host_availability
 
 - name: Domain Server Availability
   metric-dmr:
   - name: Domain Server Availability
-    attribute:    status
+    attribute: status
     metric-family: wildfly_domain_host_server_availability
 
 resource-type-set-dmr:
@@ -591,69 +591,69 @@ resource-type-set-dmr:
       attribute: uuid
     - name: Home Directory
       attribute: home-dir
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     - name: Node Name
       attribute: node-name
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     - name: Hostname
       attribute: qualified-host-name
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     - name: Bound Address
       attribute: bound-address
-      path:     /socket-binding-group=standard-sockets/socket-binding=http
+      path: /socket-binding-group=standard-sockets/socket-binding=http
     operation-dmr:
     - name: JDR
       internal-name: generate-jdr-report
-      path:          /subsystem=jdr
+      path: /subsystem=jdr
     - name: Reload
       internal-name: reload
-      modifies:      true
+      modifies: true
       params:
       - name: admin-only
-        type:          bool
+        type: bool
         default-value: "false"
-        description:   Whether the server should start in running mode ADMIN_ONLY when it restarts
+        description: Whether the server should start in running mode ADMIN_ONLY when it restarts
       - name: use-current-server-config
-        type:          bool
+        type: bool
         default-value: "false"
     - name: Resume
       internal-name: resume
-      modifies:      true
+      modifies: true
     - name: Shutdown
       internal-name: shutdown
-      modifies:      true
+      modifies: true
       params:
       - name: timeout
-        type:          int
+        type: int
         default-value: "0"
-        description:   Timeout in seconds to allow active connections to drain
+        description: Timeout in seconds to allow active connections to drain
       - name: restart
-        type:          bool
+        type: bool
         default-value: "false"
-        description:   "Should the server be restarted after shutdown?"
+        description: "Should the server be restarted after shutdown?"
     - name: Suspend
       internal-name: suspend
-      modifies:      true
+      modifies: true
       params:
       - name: timeout
-        type:          int
+        type: int
         default-value: "0"
-        description:   Timeout in seconds to allow active connections to drain
+        description: Timeout in seconds to allow active connections to drain
     - name: Deploy
       internal-name: deploy
-      modifies:      true
+      modifies: true
     - name: Undeploy
       internal-name: undeploy
-      modifies:      true
+      modifies: true
     - name: Enable Deployment
       internal-name: enable-deployment
-      modifies:      true
+      modifies: true
     - name: Disable Deployment
       internal-name: disable-deployment
-      modifies:      true
+      modifies: true
     - name: Restart Deployment
       internal-name: restart-deployment
-      modifies:      true
+      modifies: true
 
 - name: Domain Environment
   resource-type-dmr:
@@ -673,62 +673,62 @@ resource-type-set-dmr:
     operation-dmr:
     - name: Reload Servers
       internal-name: reload-servers
-      modifies:      true
+      modifies: true
       params:
       - name: blocking
-        type:          bool
-        description:   Wait until the servers are stopped before returning from the operation.
+        type: bool
+        description: Wait until the servers are stopped before returning from the operation.
     - name: Restart Servers
       internal-name: restart-servers
-      modifies:      true
+      modifies: true
       params:
       - name: blocking
-        type:          bool
-        description:   Wait until the servers are stopped before returning from the operation.
+        type: bool
+        description: Wait until the servers are stopped before returning from the operation.
     - name: Resume Servers
       internal-name: resume-servers
-      modifies:      true
+      modifies: true
     - name: Start Servers
       internal-name: start-servers
-      modifies:      true
+      modifies: true
       params:
       - name: blocking
-        type:          bool
-        description:   Wait until the servers are stopped before returning from the operation.
+        type: bool
+        description: Wait until the servers are stopped before returning from the operation.
     - name: Stop Servers
       internal-name: stop-servers
-      modifies:      true
+      modifies: true
       params:
       - name: blocking
-        type:          bool
-        description:   Wait until the servers are stopped before returning from the operation.
+        type: bool
+        description: Wait until the servers are stopped before returning from the operation.
       - name: timeout
-        type:          int
+        type: int
         default-value: "0"
-        description:   Timeout in seconds to allow active connections to drain
+        description: Timeout in seconds to allow active connections to drain
     - name: Suspend Servers
       internal-name: suspend-servers
-      modifies:      true
+      modifies: true
       params:
       - name: timeout
-        type:          int
+        type: int
         default-value: "0"
-        description:   Timeout in seconds to allow active connections to drain
+        description: Timeout in seconds to allow active connections to drain
     - name: Deploy
       internal-name: deploy
-      modifies:      true
+      modifies: true
     - name: Undeploy
       internal-name: undeploy
-      modifies:      true
+      modifies: true
     - name: Enable Deployment
       internal-name: enable-deployment
-      modifies:      true
+      modifies: true
     - name: Disable Deployment
       internal-name: disable-deployment
-      modifies:      true
+      modifies: true
     - name: Restart Deployment
       internal-name: restart-deployment
-      modifies:      true
+      modifies: true
 
   - name: Domain Profile
     resource-name-template: "%-"
@@ -750,49 +750,49 @@ resource-type-set-dmr:
     operation-dmr:
     - name: Reload Servers
       internal-name: reload-servers
-      modifies:      true
+      modifies: true
       params:
       - name: blocking
-        type:          bool
+        type: bool
         default-value: false
-        description:   Wait until the servers are stopped before returning from the operation.
+        description: Wait until the servers are stopped before returning from the operation.
     - name: Restart Servers
       internal-name: restart-servers
-      modifies:      true
+      modifies: true
       params:
       - name: blocking
-        type:          bool
+        type: bool
         default-value: false
-        description:   Wait until the servers are stopped before returning from the operation.
+        description: Wait until the servers are stopped before returning from the operation.
     - name: Resume Servers
       internal-name: resume-servers
-      modifies:      true
+      modifies: true
     - name: Start Servers
       internal-name: start-servers
-      modifies:      true
+      modifies: true
       params:
       - name: blocking
-        type:          bool
+        type: bool
         default-value: false
-        description:   Wait until the servers are stopped before returning from the operation.
+        description: Wait until the servers are stopped before returning from the operation.
     - name: Stop Servers
       internal-name: stop-servers
-      modifies:      true
+      modifies: true
       params:
       - name: blocking
-        type:          bool
+        type: bool
         default-value: false
-        description:   Wait until the servers are stopped before returning from the operation.
+        description: Wait until the servers are stopped before returning from the operation.
       - name: timeout
-        type:          int
-        description:   Timeout in seconds to allow active connections to drain
+        type: int
+        description: Timeout in seconds to allow active connections to drain
     - name: Suspend Servers
       internal-name: suspend-servers
-      modifies:      true
+      modifies: true
       params:
       - name: timeout
-        type:          int
-        description:   Timeout in seconds to allow active connections to drain
+        type: int
+        description: Timeout in seconds to allow active connections to drain
 
   - name: Domain Host
     resource-name-template: "%-"
@@ -828,17 +828,17 @@ resource-type-set-dmr:
       attribute: uuid
     - name: Home Directory
       attribute: home-dir
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     operation-dmr:
     - name: Reload
       internal-name: reload
-      modifies:      true
+      modifies: true
     - name: Shutdown
       internal-name: shutdown
-      modifies:      true
+      modifies: true
       params:
       - name: restart
-        type:        bool
+        type: bool
         description: If true, once shutdown the host controller will be restarted again.
 
   - name: Domain WildFly Server
@@ -879,23 +879,23 @@ resource-type-set-dmr:
       attribute: uuid
     - name: Hostname
       attribute: qualified-host-name
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     - name: Node Name
       attribute: node-name
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     - name: Initial Running Mode
       attribute: initial-running-mode
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     - name: Base Directory
       attribute: base-dir
-      path:      /core-service=server-environment
+      path: /core-service=server-environment
     - name: Bound Address
       attribute: bound-address
-      path:     /socket-binding-group=full-sockets/socket-binding=http
+      path: /socket-binding-group=full-sockets/socket-binding=http
     operation-dmr:
     - name: JDR
       internal-name: generate-jdr-report
-      path:          /subsystem=jdr
+      path: /subsystem=jdr
 
   - name: Domain WildFly Server Controller
     resource-name-template: "%-"
@@ -916,63 +916,63 @@ resource-type-set-dmr:
     operation-dmr:
     - name: Destroy
       internal-name: destroy
-      modifies:      true
+      modifies: true
     - name: Kill
       internal-name: kill
-      modifies:      true
+      modifies: true
     - name: Reload
       internal-name: reload
-      modifies:      true
+      modifies: true
       params:
       - name: server
         description: The name of the server.
       - name: blocking
-        type:          bool
+        type: bool
         default-value: "false"
-        description:   Wait until the servers are stopped before returning from the operation.
+        description: Wait until the servers are stopped before returning from the operation.
     - name: Restart
       internal-name: restart
-      modifies:      true
+      modifies: true
       params:
       - name: server
         description: The name of the server.
       - name: blocking
-        type:          bool
+        type: bool
         default-value: "false"
-        description:   Wait until the servers are stopped before returning from the operation.
+        description: Wait until the servers are stopped before returning from the operation.
     - name: Resume
       internal-name: resume
-      modifies:      true
+      modifies: true
     - name: Start
       internal-name: start
-      modifies:      true
+      modifies: true
       params:
       - name: server
         description: The name of the server.
       - name: blocking
-        type:          bool
+        type: bool
         default-value: "false"
-        description:   Wait until the servers are stopped before returning from the operation.
+        description: Wait until the servers are stopped before returning from the operation.
     - name: Stop
       internal-name: stop
-      modifies:      true
+      modifies: true
       params:
       - name: server
         description: The name of the server.
       - name: blocking
-        type:          bool
+        type: bool
         default-value: "false"
-        description:   Wait until the servers are stopped before returning from the operation.
+        description: Wait until the servers are stopped before returning from the operation.
       - name: timeout
-        type:          int
-        description:   Timeout in seconds to allow active connections to drain
+        type: int
+        description: Timeout in seconds to allow active connections to drain
     - name: Suspend
       internal-name: suspend
-      modifies:      true
+      modifies: true
       params:
       - name: timeout
-        type:          int
-        description:   Timeout in seconds to allow active connections to drain
+        type: int
+        description: Timeout in seconds to allow active connections to drain
 
 - name: Undertow Subsystem
   resource-type-dmr:
@@ -1118,7 +1118,7 @@ resource-type-set-dmr:
     - name: Security Domain
       attribute: security-domain
     - name: Connection Properties
-      path:      "/connection-properties=*"
+      path: "/connection-properties=*"
       attribute: value
 
 - name: XA Datasource
@@ -1150,7 +1150,7 @@ resource-type-set-dmr:
     - name: Security Domain
       attribute: security-domain
     - name: Datasource Properties
-      path:      "/xa-datasource-properties=*"
+      path: "/xa-datasource-properties=*"
       attribute: value
 
 - name: JDBC Driver
@@ -1175,7 +1175,7 @@ resource-type-set-dmr:
   resource-type-dmr:
   - name: Transaction Manager
     resource-name-template: Transaction Manager
-    path: "/subsystem=transactions"
+    path: /subsystem=transactions
     parents:
     - WildFly Server
     - Domain WildFly Server
@@ -1259,27 +1259,27 @@ resource-type-set-dmr:
 - name: Clustering
   resource-type-dmr:
   - name: ModCluster
-    resource-name-template: "ModCluster"
-    path:                   "/subsystem=modcluster"
+    resource-name-template: ModCluster
+    path: /subsystem=modcluster
     parents:
     - WildFly Server
     - Domain WildFly Server
     resource-config-dmr:
     - name: Connector
       attribute: connector
-      path:      "/mod-cluster-config=configuration"
+      path: /mod-cluster-config=configuration
     - name: Advertise Socket Binding
       attribute: advertise-socket
-      path:      "/mod-cluster-config=configuration"
+      path: /mod-cluster-config=configuration
   - name: JGroups
-    resource-name-template: "JGroups"
-    path:                   "/subsystem=jgroups"
+    resource-name-template: JGroups
+    path: /subsystem=jgroups
     parents:
     - WildFly Server
     - Domain WildFly Server
   - name: JGroups Channel
     resource-name-template: "%-"
-    path:                   "/channel=*"
+    path: "/channel=*"
     parents:
     - JGroups
     resource-config-dmr:
@@ -1291,14 +1291,14 @@ resource-type-set-dmr:
       attribute: view
 
   - name: Infinispan
-    resource-name-template: "Infinispan"
-    path:                   "/subsystem=infinispan"
+    resource-name-template: Infinispan
+    path: /subsystem=infinispan
     parents:
     - WildFly Server
     - Domain WildFly Server
   - name: Infinispan Cache Container
     resource-name-template: "%-"
-    path:                   "/cache-container=*"
+    path: "/cache-container=*"
     parents:
     - Infinispan
     resource-config-dmr:
@@ -1315,21 +1315,21 @@ metric-set-jmx:
 - name: Runtime Metrics
   metric-jmx:
   - name: VM Uptime
-    attribute:    Uptime
+    attribute: Uptime
     metric-units: milliseconds
-    metric-type:  counter
+    metric-type: counter
     metric-family: TODO
   - name: Used Heap Memory
-    object-name:  java.lang:type=Memory
-    attribute:    HeapMemoryUsage#used
+    object-name: java.lang:type=Memory
+    attribute: HeapMemoryUsage#used
     metric-units: bytes
-    metric-type:  gauge
+    metric-type: gauge
     metric-family: jvm_memory_bytes_used
     metric-labels:
       area: heap
   - name: Aggregate GC Collection Time
-    object-name:  "java.lang:type=GarbageCollector,name=*"
-    attribute:    CollectionTime
+    object-name: "java.lang:type=GarbageCollector,name=*"
+    attribute: CollectionTime
     metric-units: seconds
     metric-family: jvm_gc_collection_seconds_sum
     metric-expression: sum($metric)
@@ -1337,79 +1337,79 @@ metric-set-jmx:
 - name: Memory Pool Metrics
   metric-jmx:
   - name: Initial
-    attribute:    Usage#init
+    attribute: Usage#init
     metric-units: bytes
-    metric-type:  gauge
+    metric-type: gauge
     metric-family: jvm_memory_pool_bytes_init
   - name: Used
-    attribute:    Usage#used
+    attribute: Usage#used
     metric-units: bytes
-    metric-type:  gauge
+    metric-type: gauge
     metric-family: jvm_memory_pool_bytes_used
   - name: Committed
-    attribute:    Usage#committed
+    attribute: Usage#committed
     metric-units: bytes
-    metric-type:  gauge
+    metric-type: gauge
     metric-family: jvm_memory_pool_bytes_committed
   - name: Max
-    attribute:    Usage#max
+    attribute: Usage#max
     metric-units: bytes
-    metric-type:  gauge
+    metric-type: gauge
     metric-family: jvm_memory_pool_bytes_max
 
 - name: Platform Operating System Metrics
   metric-jmx:
   - name: System CPU Load
-    attribute:     System CPU Load
-    metric-type:   gauge
+    attribute: System CPU Load
+    metric-type: gauge
     metric-family: hawkular_platform_operatingsystem_system_cpu_load
   - name: System Load Average
-    attribute:     System Load Average
-    metric-type:   gauge
+    attribute: System Load Average
+    metric-type: gauge
     metric-family: hawkular_platform_operatingsystem_system_load_average
   - name: Process Count
-    attribute:     Process Count
-    metric-type:   gauge
+    attribute: Process Count
+    metric-type: gauge
     metric-family: hawkular_platform_operatingsystem_process_count
 
 - name: Platform File Store Metrics
   metric-jmx:
   - name: Usable Space
-    attribute:     Usable Space
-    metric-type:   gauge
+    attribute: Usable Space
+    metric-type: gauge
     metric-family: hawkular_platform_filestore_usable_space
   - name: Total Space
-    attribute:     Total Space
-    metric-type:   gauge
+    attribute: Total Space
+    metric-type: gauge
     metric-family: hawkular_platform_filestore_total_space
 
 - name: Platform Memory Metrics
   metric-jmx:
   - name: Available Memory
-    attribute:     Available Memory
-    metric-type:   gauge
+    attribute: Available Memory
+    metric-type: gauge
     metric-family: hawkular_platform_memory_available_memory
   - name: Total Memory
-    attribute:     Total Memory
-    metric-type:   gauge
+    attribute: Total Memory
+    metric-type: gauge
     metric-family: hawkular_platform_memory_total_memory
 
 - name: Platform Processor Metrics
   metric-jmx:
   - name: CPU Usage
-    attribute:     CPU Usage
-    metric-type:   gauge
+    attribute: CPU Usage
+    metric-type: gauge
     metric-family: hawkular_platform_processor_cpu_usage
 
 - name: Platform Power Source Metrics
   metric-jmx:
   - name: Remaining Capacity
-    attribute:     Remaining Capacity
-    metric-type:   gauge
+    attribute: Remaining Capacity
+    metric-type: gauge
     metric-family: hawkular_platform_powersource_remaining_capacity
   - name: Time Remaining
-    attribute:     Time Remaining
-    metric-type:   gauge
+    attribute: Time Remaining
+    metric-type: gauge
     metric-family: hawkular_platform_powersource_time_remaining
 
 resource-type-set-jmx:
@@ -1422,10 +1422,10 @@ resource-type-set-jmx:
     - Runtime Metrics
     resource-config-jmx:
     - name: OS Name
-      attribute:   Name
+      attribute: Name
       object-name: java.lang:type=OperatingSystem
     - name: Java VM Name
-      attribute:   VmName
+      attribute: VmName
 
 - name: Memory Pool
   resource-type-jmx:
@@ -1443,8 +1443,8 @@ resource-type-set-jmx:
 - name: Hawkular
   resource-type-jmx:
   - name: Hawkular Java Agent
-    resource-name-template: "Hawkular Java Agent"
-    object-name: "org.hawkular.agent:type=hawkular-javaagent"
+    resource-name-template: Hawkular Java Agent
+    object-name: org.hawkular.agent:type=hawkular-javaagent
     resource-config-jmx:
     - name: Immutable
       attribute: Immutable
@@ -1470,7 +1470,7 @@ resource-type-set-jmx:
   resource-type-jmx:
   - name: Platform Operating System
     resource-name-template: Platform Operating System
-    object-name: "org.hawkular.agent:type=platform,subtype=operatingsystem"
+    object-name: org.hawkular.agent:type=platform,subtype=operatingsystem
     resource-config-jmx:
     - name: Machine Id
       attribute: Machine Id
@@ -1493,7 +1493,7 @@ resource-type-set-jmx:
     parents:
     - Platform Operating System
     resource-name-template: Platform Memory
-    object-name: "org.hawkular.agent:type=platform,subtype=memory"
+    object-name: org.hawkular.agent:type=platform,subtype=memory
     metric-sets:
     - Platform Memory Metrics
   - name: Platform Processor


### PR DESCRIPTION
This is a PR that doesn't change any functionality - but it does clean up the yaml config files. There are lots of trivial changes here (we had some weird spacing/indentation in many values and quoted things we didn't need to) - just doing this all at once to make the yaml files more consistent and will avoid irrelevant diffs later if this gets fixed little by little. Just do it all now in this PR.

I'll do the same for the agent yaml files too.