### PR TITLE
Enable JDBC events to reach CommandEventListener

### DIFF
--- a/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/AddJdbcDriverResponse.schema.json
+++ b/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/AddJdbcDriverResponse.schema.json
@@ -5,6 +5,7 @@
     "javaType": "org.hawkular.cmdgw.api.ResourceResponse"
   },
   "javaType": "org.hawkular.cmdgw.api.AddJdbcDriverResponse",
+  "javaInterfaces" : ["org.hawkular.cmdgw.api.EventDestination"],
   "description": "Results of an Add Driver request.",
   "additionalProperties": false,
   "properties": {

--- a/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/RemoveJdbcDriverResponse.schema.json
+++ b/hawkular-command-gateway/hawkular-command-gateway-api/src/main/resources/schema/RemoveJdbcDriverResponse.schema.json
@@ -5,6 +5,7 @@
     "javaType": "org.hawkular.cmdgw.api.ResourceResponse"
   },
   "javaType": "org.hawkular.cmdgw.api.RemoveJdbcDriverResponse",
+  "javaInterfaces" : ["org.hawkular.cmdgw.api.EventDestination"],
   "description": "Results of an RemoveJdbcDriverRequest.",
   "additionalProperties": false
 }


### PR DESCRIPTION
When I added the JDBC event mapping for MIQ in the related PR, I didn't know JDBC responses are not reaching the CommandEventListener, let's fix it.

I'm not sure if this is the proper fix, please correct me if I'm wrong. I'm trying to test it, but without success so far (I'm not able to build the hawkular-services properly). Can you please help me to test that?

Related to: https://github.com/hawkular/hawkular-services/pull/191
Fixes: [BUG 1515476](https://bugzilla.redhat.com/show_bug.cgi?id=1515476)

cc @jshaughn