### PR TITLE
HAWKULAR-1339 Remove msg message to HawkularTopic

### DIFF
--- a/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/command/ws/server/FeedWebSocket.java
+++ b/hawkular-command-gateway/hawkular-command-gateway-war/src/main/java/org/hawkular/cmdgw/command/ws/server/FeedWebSocket.java
@@ -25,14 +25,6 @@ import javax.websocket.Session;
 import javax.websocket.server.PathParam;
 import javax.websocket.server.ServerEndpoint;
 
-import org.hawkular.bus.common.ConnectionContextFactory;
-import org.hawkular.bus.common.Endpoint;
-import org.hawkular.bus.common.MessageId;
-import org.hawkular.bus.common.MessageProcessor;
-import org.hawkular.bus.common.producer.ProducerConnectionContext;
-import org.hawkular.cmdgw.Constants;
-import org.hawkular.cmdgw.api.FeedWebSocketClosedEvent;
-import org.hawkular.cmdgw.command.ws.WsCommandContext;
 import org.hawkular.cmdgw.log.GatewayLoggers;
 import org.hawkular.cmdgw.log.MsgLogger;
 
@@ -55,22 +47,6 @@ public class FeedWebSocket extends AbstractGatewayWebSocket {
     @OnClose
     public void feedSessionClose(Session session, CloseReason reason, @PathParam("feedId") String feedId) {
         log.infoWsSessionClosed(feedId, endpoint, reason);
-
-        // Notify bus that connection to the feed has been lost
-        WsCommandContext context = commandContextFactory.newCommandContext(session);
-        try (ConnectionContextFactory ccf = new ConnectionContextFactory(context.getConnectionFactory())) {
-            Endpoint endpoint = Constants.HAWKULAR_TOPIC;
-            ProducerConnectionContext pcc = ccf.createProducerConnectionContext(endpoint);
-            FeedWebSocketClosedEvent message = new FeedWebSocketClosedEvent();
-            message.setFeedId(feedId);
-            message.setReason(reason.getReasonPhrase());
-            message.setCode(String.valueOf(reason.getCloseCode().getCode()));
-            MessageId mid = new MessageProcessor().send(pcc, message);
-        } catch (Exception e) {
-            log.errorFailedSendFeedClosedEvent(e, feedId, reason.getReasonPhrase(),
-                    String.valueOf(reason.getCloseCode()));
-        }
-
         wsEndpoints.getFeedSessions().removeSession(feedId, session);
     }
 


### PR DESCRIPTION
HawkularTopic was used in BackfillCache feature which is no longer on HAWKULAR-1275, so sending this message on websocket close is not necessary and might cause errors on server log.

